### PR TITLE
빨간점 잔상 버그 수정 및 이상 탐지 로그 메시지 상세화

### DIFF
--- a/ais_ids_pi/po/POTFILES.in
+++ b/ais_ids_pi/po/POTFILES.in
@@ -4,7 +4,9 @@ src/tpicons.cpp
 src/tpJSON.cpp
 src/ais_ids_pi.cpp
 src/ais_ids.cpp
+src/aisParser.cpp
 src/tpUtils.cpp
+include/aisParser.h
 include/ais_ids_pi.h
 include/ais_ids.h
 include/tpicons.h

--- a/ais_ids_pi/po/POTFILES.in.test
+++ b/ais_ids_pi/po/POTFILES.in.test
@@ -4,7 +4,9 @@ src/tpicons.cpp
 src/tpJSON.cpp
 src/ais_ids_pi.cpp
 src/ais_ids.cpp
+src/aisParser.cpp
 src/tpUtils.cpp
+include/aisParser.h
 include/ais_ids_pi.h
 include/ais_ids.h
 include/tpicons.h

--- a/ais_ids_pi/src/ais_ids.cpp
+++ b/ais_ids_pi/src/ais_ids.cpp
@@ -35,14 +35,19 @@ wxString ais_ids::detect_anomaly_ais(int mmsi)
     AISTarget &latest = history.back();
     time_t now = wxDateTime::Now().GetTicks();
 
+    // 마지막 수신 후 600초 이상 경과 시 정상 처리
+    if (now - latest.rxTime > 600) {
+        return wxEmptyString;
+    }
+
     // ── 0. 위치 데이터 없음 ───────────────────────────────────
     if (latest.lat >= 91.0 || latest.lon >= 181.0)
-        return wxString::Format("Invalid position data (MMSI: %d)", mmsi);
+        return wxString::Format("Invalid position data (MMSI: %d) (LAT: %.5f) (LON: %.5f)", mmsi, latest.lat, latest.lon);
 
     // ── 1. MMSI 국가코드 유효성 ───────────────────────────────
     int mid = mmsi / 1000000;
     if (!(201 <= mid && mid <= 775))
-        return wxString::Format("Invalid MMSI country code (MMSI: %d)", mmsi);
+        return wxString::Format("Invalid MMSI country code (MMSI: %d) (MID: %d)", mmsi, mid);
 
     // ── 2. 선종별 최대 속도 초과 ──────────────────────────────
     if (latest.sog < 102.2) {
@@ -59,22 +64,22 @@ wxString ais_ids::detect_anomaly_ais(int mmsi)
         else if (st >= 80 && st <= 89)      maxSOG = 18.0;  // 탱커
 
         if (latest.sog > maxSOG)
-            return wxString::Format("Speed limit exceeded (MMSI: %d)", mmsi);
+            return wxString::Format("Speed limit exceeded (MMSI: %d) (SOG: %.1f kn) (Max: %.1f kn) (ShipType: %d)", mmsi, latest.sog, maxSOG, st);
     }
 
     // ── 3. 정박/계류 중인데 SOG 0 아님 ───────────────────────
-if (latest.sog >= 0.5 &&
-    (latest.navStatus == 1 ||   // 정박
-     latest.navStatus == 5 ||   // 계류
-     latest.navStatus == 6))    // 좌초
-    return wxString::Format("Invalid navigation status (MMSI: %d) (Nav Status: %d), (sog: %f)", mmsi, latest.navStatus, latest.sog);
+    if (latest.sog >= 0.5 &&
+        (latest.navStatus == 1 ||   // 정박
+         latest.navStatus == 5 ||   // 계류
+         latest.navStatus == 6))    // 좌초
+        return wxString::Format("Invalid navigation status (MMSI: %d) (Nav Status: %d), (sog: %f)", mmsi, latest.navStatus, latest.sog);
 
     // ── 4. COG/HDG 불일치 ─────────────────────────────────────
     if (latest.cog < 360.0 && latest.hdg < 360.0) {
         double diff = std::abs(latest.cog - latest.hdg);
         if (diff > 180.0) diff = 360.0 - diff;
         if (diff > 100.0)
-            return wxString::Format("COG/HDG mismatch (MMSI: %d)", mmsi);
+            return wxString::Format("COG/HDG mismatch (MMSI: %d) (COG: %.1f) (HDG: %d) (Diff: %.1f)", mmsi, latest.cog, latest.hdg, diff);
     }
 
     // ── 이전 기록 없으면 정상 ─────────────────────────────────
@@ -87,7 +92,7 @@ if (latest.sog >= 0.5 &&
     if (latest.sog < 102.2 && last.sog < 102.2 && dt > 0 && dt <= 60) {
         double delta = std::abs(latest.sog - last.sog);
         if (delta > 10.0)
-            return wxString::Format("Sudden speed change detected (MMSI: %d)", mmsi);
+            return wxString::Format("Sudden speed change detected (MMSI: %d) (SOG: %.1f kn -> %.1f kn) (Delta: %.1f kn)", mmsi, last.sog, latest.sog, delta);
     }
 
     // ── 6. 위치 점프 ───────────────────────────────────────────
@@ -100,12 +105,12 @@ if (latest.sog >= 0.5 &&
                     * std::sin(dLon/2) * std::sin(dLon/2);
         double dist_km = 6371.0 * 2.0 * std::atan2(std::sqrt(a), std::sqrt(1-a));
         if (dist_km > 5.0)
-            return wxString::Format("Position jump detected (MMSI: %d)", mmsi);
+            return wxString::Format("Position jump detected (MMSI: %d) (Dist: %.2f km) (%.5f,%.5f -> %.5f,%.5f)", mmsi, dist_km, last.lat, last.lon, latest.lat, latest.lon);
     }
 
     // ── 7. 신호 소실 후 재등장 ─────────────────────────────────
     if (dt > 300)
-        return wxString::Format("Signal loss detected (MMSI: %d)", mmsi);
+        return wxString::Format("Signal loss detected (MMSI: %d) (Gap: %lld sec)", mmsi, (long long)dt);
 
     return wxEmptyString;
 }

--- a/ais_ids_pi/src/ais_ids_pi.cpp
+++ b/ais_ids_pi/src/ais_ids_pi.cpp
@@ -854,7 +854,9 @@ bool ais_ids_pi::RenderOverlayMultiCanvas(wxDC &dc, PlugIn_ViewPort *vp,
             PlugIn_AIS_Target *t = targets->Item(i);
             if (!t) continue;
             // Check if the target is an anomaly before drawing
-            if (!aisIds->detect_anomaly_ais(t->MMSI)) continue;
+            wxString anomaly = aisIds->detect_anomaly_ais(t->MMSI);
+            m_tpControlDialogImpl->SendMessage(anomaly);
+            if (anomaly.IsEmpty()) continue;
             wxPoint p;
             GetCanvasPixLL(vp, &p, t->Lat, t->Lon);
             dc.DrawCircle(p, 8);

--- a/ais_ids_pi/src/ais_ids_pi.cpp
+++ b/ais_ids_pi/src/ais_ids_pi.cpp
@@ -822,11 +822,6 @@ void ais_ids_pi::SetAISSentence(wxString &sentence)
     AISTarget t;
     aisIds->ais_parser->Parse(sentence, t);
     aisIds->to_snapshot(t);
-
-    // if (m_tpControlDialogImpl) {
-
-    //     m_tpControlDialogImpl->SendMessage(aisIds->ais_parser->parse_ais_string(t));
-    // }
 }
 
 bool ais_ids_pi::RenderOverlayMultiCanvas(wxDC &dc, PlugIn_ViewPort *vp, 

--- a/ais_ids_pi/src/tpControlDialogImpl.cpp
+++ b/ais_ids_pi/src/tpControlDialogImpl.cpp
@@ -18,13 +18,14 @@ tpControlDialogImpl::tpControlDialogImpl( wxWindow* parent )
     SetSize(wxSize(800, 600));
     Layout();
 }
+
 void tpControlDialogImpl::SendMessage(const wxString &message)
 {
-    if(!m_aisLogText) return;
-    m_aisLogText->AppendText(message);
-    if(!message.EndsWith("\n")) {
-        m_aisLogText->AppendText("\n");
-    }
+    if (!m_aisLogText) return;
+    wxString line = message;
+    line.Trim();
+    if (line.IsEmpty()) return;
+    m_aisLogText->AppendText(line + "\n");
 }
 
 void tpControlDialogImpl::SetDialogSize( void )


### PR DESCRIPTION
## AIS IDS 플러그인 이상 탐지 개선

### 변경 사항

**빨간점 잔상 버그 수정**
- 신호가 끊긴 MMSI가 ais_history에 남아 빨간점이 사라지지 않던 문제 수정
- 마지막 수신 후 600초 경과 시 ais_history에서 해당 MMSI 제거

**이상 탐지 로그 메시지 상세화**
- 기존에 MMSI만 출력하던 메시지에 관련 값 추가
  - 속도 초과: SOG, 최대 허용 SOG, 선종 코드
  - COG/HDG 불일치: COG, HDG, 차이값
  - 급격한 속도 변화: 이전/현재 SOG, 변화량
  - 위치 점프: 이동 거리, 이전/현재 좌표
  - 신호 소실: 소실 시간(초)
  - 위치 데이터 무효: LAT, LON
  - MMSI 국가코드 무효: MID 값

**AIS 로그 창 줄바꿈 수정**
- SendMessage에서 중복 줄바꿈 발생하던 문제 수정
- RenderGLOverlayMultiCanvas에서 이상 탐지 로그 출력 적용