### PR TITLE
FN 시나리오 평가 추가 및 학습 시간 로깅

### DIFF
--- a/ml/eval_anomaly.py
+++ b/ml/eval_anomaly.py
@@ -205,6 +205,129 @@ def make_position_jump_seq():
     return seq
 
 
+# ── FN 시나리오 (aivdm_gen 회피 케이스) ─────────────
+def make_fn_dt_jump_seq():
+    """[FN-1] dt 구간 점프: 전송 간격 61~299초로 위치/속도 급변
+    → 룰 기반 Check 5/6/7 모두 회피."""
+    sog = random.uniform(5.0, 12.0)
+    cog = random.uniform(0, 360)
+    seq = []
+    lat, lon = 37.0, 126.0
+    prev_sog, prev_cog = sog, cog
+    for i in range(SEQ_LEN):
+        dt = random.uniform(61, 299)
+        direction = random.uniform(0, 360)
+        jump = random.uniform(0.08, 0.20)
+        dist_km = jump * 111.0
+        lat += math.cos(math.radians(direction)) * jump
+        lon += math.sin(math.radians(direction)) * jump
+        sog = random.choice([2.0, 18.0, 3.0, 20.0])
+        cog = random.uniform(0, 360)
+        hdg = int(cog)
+        cog_hdg_diff = 0.0
+        expected_dist = sog * dt / 3600 * 1.852
+        sog_change = abs(sog - prev_sog)
+        cog_change = 0.0
+        status_sog_product = 0.0
+        dist_expected_ratio = dist_km / (expected_dist + 1e-6)
+        seq.append([sog, cog, hdg, 0, dt, dist_km, expected_dist, 0.0, cog_hdg_diff,
+                    sog_change, cog_change, status_sog_product, dist_expected_ratio])
+        prev_sog, prev_cog = sog, cog
+    return seq
+
+
+def make_fn_speed_ramp_seq():
+    """[FN-2] 속도 단계 상승: 매번 9.5kn씩 증가 → Check 5(Δ>10) 회피"""
+    ramp_start = 2.0
+    ramp_step  = 9.5
+    ramp_max   = 29.0
+    cog = random.uniform(0, 360)
+    sog = ramp_start
+    seq = []
+    lat, lon = 37.0, 126.0
+    prev_sog = sog
+    for i in range(SEQ_LEN):
+        dt = random.uniform(30, 55)
+        dist_km = sog * dt / 3600 * 1.852
+        lat += math.cos(math.radians(cog)) * dist_km / 111.0
+        lon += math.sin(math.radians(cog)) * dist_km / 111.0
+        hdg = int(cog)
+        cog_hdg_diff = 0.0
+        expected_dist = sog * dt / 3600 * 1.852
+        sog_change = abs(sog - prev_sog)
+        cog_change = 0.0
+        status_sog_product = 0.0
+        dist_expected_ratio = dist_km / (expected_dist + 1e-6)
+        seq.append([sog, cog, hdg, 0, dt, dist_km, expected_dist, 0.0, cog_hdg_diff,
+                    sog_change, cog_change, status_sog_product, dist_expected_ratio])
+        prev_sog = sog
+        sog = min(sog + ramp_step, ramp_max)
+        if sog >= ramp_max:
+            sog = ramp_start
+    return seq
+
+
+def make_fn_cog_border_seq():
+    """[FN-3] COG/HDG 경계값: 불일치 91~99도 → Check 4(>100) 회피"""
+    sog = random.uniform(3.0, 10.0)
+    cog = random.uniform(0, 360)
+    mismatch = random.uniform(91, 99)
+    seq = []
+    lat, lon = 37.0, 126.0
+    prev_sog, prev_cog = sog, cog
+    for i in range(SEQ_LEN):
+        dt = random.uniform(10, 30)
+        dist_km = sog * dt / 3600 * 1.852
+        lat += math.cos(math.radians(cog)) * dist_km / 111.0
+        lon += math.sin(math.radians(cog)) * dist_km / 111.0
+        hdg = int((cog + mismatch) % 360)
+        cog_hdg_diff = abs(cog - hdg)
+        if cog_hdg_diff > 180: cog_hdg_diff = 360 - cog_hdg_diff
+        expected_dist = sog * dt / 3600 * 1.852
+        sog_change = abs(sog - prev_sog)
+        cog_diff = abs(cog - prev_cog)
+        if cog_diff > 180: cog_diff = 360 - cog_diff
+        status_sog_product = 0.0
+        dist_expected_ratio = dist_km / (expected_dist + 1e-6)
+        seq.append([sog, cog, hdg, 0, dt, dist_km, expected_dist, 0.0, cog_hdg_diff,
+                    sog_change, cog_diff, status_sog_product, dist_expected_ratio])
+        prev_sog, prev_cog = sog, cog
+        if random.random() < 0.1:
+            cog = (cog + random.uniform(-10, 10)) % 360
+    return seq
+
+
+def make_fn_nav_status_seq():
+    """[FN-4] navStatus 회피: status=2/3/7/8/11/12 이면서 이동
+    → Check 3은 status=1/5/6만 검사 → 탐지 안됨."""
+    unchecked = [2, 3, 7, 8, 11, 12]
+    status = random.choice(unchecked)
+    sog = random.uniform(0.5, 5.0)
+    cog = random.uniform(0, 360)
+    seq = []
+    lat, lon = 37.0, 126.0
+    prev_sog, prev_cog = sog, cog
+    for i in range(SEQ_LEN):
+        dt = random.uniform(10, 30)
+        dist_km = sog * dt / 3600 * 1.852
+        lat += math.cos(math.radians(cog)) * dist_km / 111.0
+        lon += math.sin(math.radians(cog)) * dist_km / 111.0
+        hdg = int(cog)
+        cog_hdg_diff = 0.0
+        expected_dist = sog * dt / 3600 * 1.852
+        sog_change = abs(sog - prev_sog)
+        cog_diff = abs(cog - prev_cog)
+        if cog_diff > 180: cog_diff = 360 - cog_diff
+        status_sog_product = status * sog
+        dist_expected_ratio = dist_km / (expected_dist + 1e-6)
+        seq.append([sog, cog, hdg, status, dt, dist_km, expected_dist, 0.0, cog_hdg_diff,
+                    sog_change, cog_diff, status_sog_product, dist_expected_ratio])
+        prev_sog, prev_cog = sog, cog
+        if random.random() < 0.05:
+            cog = (cog + random.uniform(-15, 15)) % 360
+    return seq
+
+
 # ── 메인 ─────────────────────────────────────────
 
 
@@ -229,6 +352,10 @@ def main():
         ("정박 이동",       [make_anchor_move_seq()       for _ in range(N)]),
         ("속도 이상",       [make_speed_spike_seq()       for _ in range(N)]),
         ("위치 점프",       [make_position_jump_seq()     for _ in range(N)]),
+        ("FN1-dt점프",     [make_fn_dt_jump_seq()        for _ in range(N)]),
+        ("FN2-속도단계",   [make_fn_speed_ramp_seq()     for _ in range(N)]),
+        ("FN3-COG경계",   [make_fn_cog_border_seq()     for _ in range(N)]),
+        ("FN4-status회피", [make_fn_nav_status_seq()     for _ in range(N)]),
     ]
 
     ne = np.array(normal_errors)

--- a/ml/train.py
+++ b/ml/train.py
@@ -14,6 +14,7 @@ AIS LSTM Autoencoder 학습 스크립트
 import csv
 import json
 import random
+import time
 from collections import defaultdict
 
 import torch
@@ -304,18 +305,22 @@ def calc_threshold(model, loader, device) -> float:
 
 # ── 메인 ──────────────────────────────────────────────────────────
 def main():
+    t_start = time.time()
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     print(f"[디바이스] {device}")
 
     # 1. 데이터 로드
+    _t1 = time.time()
     print("[1/6] 데이터 로드...")
     mmsi_data = load_data(INPUT_FILE)
 
     # 2. 시퀀스 생성
+    _t2 = time.time()
     print("[2/6] 시퀀스 생성...")
     sequences = make_sequences(mmsi_data)
 
     # 3. 정규화
+    _t3 = time.time()
     print("[3/6] 정규화...")
     flat   = [row for seq in sequences for row in seq]
     scaler = MinMaxScaler()
@@ -328,6 +333,7 @@ def main():
     print(f"  스케일러 저장: {SCALER_FILE}")
 
     # 4. Dataset / DataLoader (train / val 분리)
+    _t4 = time.time()
     print("[4/6] 학습 준비...")
     tensor   = torch.tensor(scaled, dtype=torch.float32)
     dataset  = TensorDataset(tensor)
@@ -342,6 +348,7 @@ def main():
     print(f"  학습: {n_train:,}  검증: {n_val:,}")
 
     # 5. 학습 + ONNX 변환
+    _t5 = time.time()
     print("[5/6] 학습 시작...")
     model = LSTMAutoencoder(
         input_size=len(FEATURES),
@@ -352,13 +359,25 @@ def main():
     export_onnx(model, device)
 
     # 6. 임계값 계산 (train 셋 오차 분포 기준, 검증 셋 누수 방지)
+    _t6 = time.time()
     print("[6/6] 임계값 계산...")
     threshold = calc_threshold(model, train_loader, device)
     with open(THRESHOLD_FILE, "w") as f:
         f.write(str(threshold))
     print(f"  임계값: {threshold:.6f}  (상위 {100 - THRESHOLD_PERCENTILE}%)")
     print(f"  임계값 저장: {THRESHOLD_FILE}")
+    t_end = time.time()
     print("완료!")
+    print("")
+    print(f"  [소요 시간]")
+    print(f"  데이터 로드:   {_t2-_t1:6.1f}s")
+    print(f"  시퀀스 생성:   {_t3-_t2:6.1f}s")
+    print(f"  정규화:        {_t4-_t3:6.1f}s")
+    print(f"  학습 준비:     {_t5-_t4:6.1f}s")
+    print(f"  학습+ONNX:     {_t6-_t5:6.1f}s")
+    print(f"  임계값 계산:   {t_end-_t6:6.1f}s")
+    print(f"  ─────────────────────")
+    print(f"  전체:          {t_end-t_start:6.1f}s")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## FN 시나리오 평가 추가 및 학습 시간 로깅

### 변경 사항

**`eval_anomaly.py`**
- FN1~FN4 시나리오 추가 (aivdm_gen 룰 회피 케이스)
  - FN1: dt 구간 점프 (61~299초로 Check 5/6/7 회피)
  - FN2: 속도 단계 상승 (9.5kn씩 증가로 Check 5 회피)
  - FN3: COG/HDG 경계값 (91~99도로 Check 4 회피)
  - FN4: navStatus 회피 (status=2/3/7/8/11/12 이면서 이동)

**`train.py`**
- 단계별 소요 시간 출력 추가 (데이터 로드 / 시퀀스 생성 / 정규화 / 학습 준비 / 학습+ONNX / 임계값 계산 / 전체)