### PR TITLE
ML 출력 구조 개선 및 CI 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,32 @@
 ais_ids_pi/build
 ais_ids_pi/po
 
-ml/threshold.txt
-ml/scaler.json
-ml/model.onnx
+# ml: 데이터 파일 (data/ 디렉터리)
+ml/data/
+
+# ml: 학습 아웃풋 (output/ 디렉터리)
+ml/output/
+
+# 이전 방식 폴백 (ml/ 루트에 남아있는 경우)
 ml/*.csv
+ml/*.onnx
+ml/threshold*.txt
+ml/scaler*.json
+ml/eval_result_*.txt
 
 aivdm_gen/*.csv
+
+# 런타임 생성 파일
+ais_ids_alerts.log
+*.log
+
+# Python 캐시
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.Python
+*.egg-info/
+dist/
+build/
+.pytest_cache/

--- a/ml/eval_anomaly.py
+++ b/ml/eval_anomaly.py
@@ -20,10 +20,13 @@ OR 앙상블 평가 (개별 임계값 기준):
     python eval_anomaly.py --weighted dcdetect tranad --weights 0.7 0.3 --target_fp 5.0
     python eval_anomaly.py --weighted dcdetect tranad conv1d --weights 0.6 0.2 0.2
 
+입력 데이터:
+    data/ais-2025-01-25_preprocessed.csv
+
 결과 파일:
-    eval_result_{model}.txt
-    eval_result_{model1}_{model2}_ensemble.txt
-    eval_result_{model1}_{model2}_weighted.txt
+    output/{model}/eval_result_{model}.txt
+    output/ensemble/eval_result_{model1}_{model2}_ensemble.txt
+    output/ensemble/eval_result_{model1}_{model2}_weighted.txt
 """
 
 import argparse

--- a/ml/eval_anomaly.py
+++ b/ml/eval_anomaly.py
@@ -29,6 +29,7 @@ OR 앙상블 평가 (개별 임계값 기준):
 import argparse
 import json
 import math
+import os
 import random
 import numpy as np
 import onnxruntime as ort
@@ -66,10 +67,12 @@ FEATURES = [
     "lat_speed", "lon_speed",
 ]
 SEQ_LEN        = 10
-MODEL_FILE     = "model.onnx"
-SCALER_FILE    = "scaler.json"
-THRESHOLD_FILE = "threshold.txt"
-DATA_FILE      = "ais-2025-01-25_preprocessed.csv"
+OUTPUT_DIR     = "output"
+DATA_DIR       = "data"
+MODEL_FILE     = f"{OUTPUT_DIR}/model.onnx"
+SCALER_FILE    = f"{OUTPUT_DIR}/scaler.json"
+THRESHOLD_FILE = f"{OUTPUT_DIR}/threshold.txt"
+DATA_FILE      = f"{DATA_DIR}/ais-2025-01-25_preprocessed.csv"
 SEQ_BREAK_DT   = 600   # 이 시간(초) 이상 간격이면 새 세그먼트로 분리
 _KN_TO_DPS     = 1852.0 / 111320.0 / 3600.0   # knot → deg/s
 
@@ -89,13 +92,14 @@ _pre = argparse.ArgumentParser(add_help=False)
 _pre.add_argument("--model", type=str, default=None)  # choices 검증 없이 받음
 _args_pre, _ = _pre.parse_known_args()
 if _args_pre.model and _args_pre.model in _KNOWN_MODELS:
-    MODEL_FILE     = f"model_{_args_pre.model}.onnx"
-    # 지도 학습 모델은 공유 스케일러(scaler_dcdetect.json) 사용
+    _mdir = os.path.join(OUTPUT_DIR, _args_pre.model)
+    MODEL_FILE     = os.path.join(_mdir, f"model_{_args_pre.model}.onnx")
+    THRESHOLD_FILE = os.path.join(_mdir, f"threshold_{_args_pre.model}.txt")
+    # 지도 학습 모델은 전용 스케일러(scaler_sup.json) 사용
     if _args_pre.model in _SUP_MODELS:
-        SCALER_FILE = "scaler_dcdetect.json"
+        SCALER_FILE = os.path.join(OUTPUT_DIR, "scaler_sup.json")
     else:
-        SCALER_FILE = f"scaler_{_args_pre.model}.json"
-    THRESHOLD_FILE = f"threshold_{_args_pre.model}.txt"
+        SCALER_FILE = os.path.join(OUTPUT_DIR, f"scaler_{_args_pre.model}.json")
 
 IS_SUPERVISED = MODEL_FILE.startswith("model_sup_")
 
@@ -903,7 +907,7 @@ def analysis_detection_weighted(sessions, model_names, weights, mins, maxs,
     print("\n→ 가중 앙상블: score = " +
           " + ".join(f"{w:.2f}×MSE({n})" for w,n in zip(weights, model_names)))
     print(f"→ 임계값 저장: threshold_weighted_ensemble.txt")
-    with open("threshold_weighted_ensemble.txt", "w") as f:
+    with open(f"{OUTPUT_DIR}/threshold_weighted_ensemble.txt", "w") as f:
         f.write(f"{thr}\n# weights: {dict(zip(model_names, weights))}")
 
 # ══════════════════════════════════════════════════════════════════
@@ -1358,13 +1362,20 @@ def main():
     run_all = not any([args.corr, args.recon, args.perm])
 
     # output 기본값: 모델명 포함
+    os.makedirs(OUTPUT_DIR, exist_ok=True)
+    os.makedirs(DATA_DIR,   exist_ok=True)
+
     if args.output is None:
         if args.weighted:
-            args.output = f"eval_result_{'_'.join(args.weighted)}_weighted.txt"
+            args.output = os.path.join(OUTPUT_DIR, "ensemble",
+                                       f"eval_result_{'_'.join(args.weighted)}_weighted.txt")
         elif args.ensemble:
-            args.output = f"eval_result_{'_'.join(args.ensemble)}_ensemble.txt"
+            args.output = os.path.join(OUTPUT_DIR, "ensemble",
+                                       f"eval_result_{'_'.join(args.ensemble)}_ensemble.txt")
         else:
-            args.output = f"eval_result_{args.model or 'lstm'}.txt"
+            _m = args.model or "lstm"
+            args.output = os.path.join(OUTPUT_DIR, _m, f"eval_result_{_m}.txt")
+    os.makedirs(os.path.dirname(args.output), exist_ok=True)
 
     # ── 앙상블 모드 ──────────────────────────────────────────────
     # python eval_anomaly.py --ensemble conv1d tranad
@@ -1376,8 +1387,8 @@ def main():
         model_names = args.weighted
         w_sessions, w_scalers = [], []
         for name in model_names:
-            w_sessions.append(ort.InferenceSession(f"model_{name}.onnx", providers=["CPUExecutionProvider"]))
-            w_scalers.append(load_scaler(f"scaler_{name}.json"))
+            w_sessions.append(ort.InferenceSession(os.path.join(OUTPUT_DIR, name, f"model_{name}.onnx"), providers=["CPUExecutionProvider"]))
+            w_scalers.append(load_scaler(os.path.join(OUTPUT_DIR, f"scaler_{name}.json")))
         mins, maxs = w_scalers[0]
         n_models = len(model_names)
         weights = args.weights if args.weights and len(args.weights)==n_models                   else [1.0/n_models]*n_models
@@ -1388,10 +1399,10 @@ def main():
         model_names = args.ensemble
         sessions, thresholds, scalers = [], [], []
         for name in model_names:
-            sessions.append(ort.InferenceSession(f"model_{name}.onnx", providers=["CPUExecutionProvider"]))
-            with open(f"threshold_{name}.txt") as f:
+            sessions.append(ort.InferenceSession(os.path.join(OUTPUT_DIR, name, f"model_{name}.onnx"), providers=["CPUExecutionProvider"]))
+            with open(os.path.join(OUTPUT_DIR, name, f"threshold_{name}.txt")) as f:
                 thresholds.append(float(f.read()))
-            scalers.append(load_scaler(f"scaler_{name}.json"))
+            scalers.append(load_scaler(os.path.join(OUTPUT_DIR, f"scaler_{name}.json")))
         mins, maxs = scalers[0]
     else:
         mins, maxs = load_scaler(SCALER_FILE)

--- a/ml/train_supervised.py
+++ b/ml/train_supervised.py
@@ -44,9 +44,13 @@ AIS 이상 탐지 지도 학습 스크립트 (5개 최신 모델)
   python train_supervised.py --model itrans --n_anom 1000 --n_normal 20000
   python train_supervised.py --model all --max_mmsi 200   # MMSI 200개로 제한
 
+입력 데이터:
+  data/*.csv                  정상 AIS 데이터 (CSV)
+
 출력 파일:
-  model_sup_{name}.onnx       ONNX 모델 (input="x" → output="output" 확률 스칼라)
-  threshold_sup_{name}.txt    최적 판정 임계값 (Youden's J 기준)
+  output/scaler_sup.json               지도학습 전용 스케일러 (CSV에서 자동 계산)
+  output/sup_{name}/model_sup_{name}.onnx      ONNX 모델
+  output/sup_{name}/threshold_sup_{name}.txt   최적 판정 임계값 (Youden's J 기준)
 """
 
 import argparse

--- a/ml/train_supervised.py
+++ b/ml/train_supervised.py
@@ -79,7 +79,9 @@ SEQ_LEN        = 10
 N_FEAT         = len(FEATURES)   # 12
 SEED           = 42
 SEQ_BREAK_DT   = 600
-SCALER_SOURCE  = "scaler_dcdetect.json"   # 재사용할 기존 스케일러
+SCALER_SUP     = "output/scaler_sup.json"   # 지도 학습 전용 스케일러
+OUTPUT_DIR     = "output"   # 모델·임계값 출력 디렉터리
+DATA_DIR       = "data"     # CSV 입력 데이터 디렉터리
 
 random.seed(SEED)
 torch.manual_seed(SEED)
@@ -107,9 +109,20 @@ DEFAULTS = {
 def load_scaler(path: str):
     with open(path) as f:
         j = json.load(f)
-    mins = j["min"]
-    maxs = j["max"]
+    return j["min"], j["max"]
+
+def compute_scaler(raw_seqs: list):
+    """raw 시퀀스 리스트에서 피처별 min/max 계산"""
+    all_rows = [row for seq in raw_seqs for row in seq]
+    arr = np.array(all_rows, dtype=np.float32)
+    mins = arr.min(axis=0).tolist()
+    maxs = arr.max(axis=0).tolist()
     return mins, maxs
+
+def save_scaler(mins, maxs, path: str):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as f:
+        json.dump({"min": mins, "max": maxs}, f, indent=2)
 
 def scale_seq(seq, mins, maxs) -> list:
     out = []
@@ -127,8 +140,9 @@ def scale_seq(seq, mins, maxs) -> list:
 # 데이터 파이프라인
 # ══════════════════════════════════════════════════════════════════
 
-def load_normal_from_csv(path: str, mins, maxs,
-                         max_seqs: int = 15000, max_mmsi: int = None) -> list:
+def load_normal_from_csv(path: str, max_seqs: int = 15000,
+                         max_mmsi: int = None) -> list:
+    """CSV에서 raw(스케일링 전) 정상 시퀀스 로드"""
     if not os.path.exists(path):
         return []
     print(f"  [정상] CSV 로드: {path}")
@@ -169,35 +183,44 @@ def load_normal_from_csv(path: str, mins, maxs,
 
     random.shuffle(all_seqs)
     sampled = all_seqs[:max_seqs]
-    scaled  = [scale_seq(seq, mins, maxs) for seq in sampled]
     mmsi_info = f"{len(mmsis):,}개 MMSI" + (f" (전체 {len(mmsi_data):,}개 중)" if max_mmsi else "")
-    print(f"    → {len(scaled):,}개 ({mmsi_info}, 전체 풀: {len(all_seqs):,})")
-    return scaled
+    print(f"    → {len(sampled):,}개 ({mmsi_info}, 전체 풀: {len(all_seqs):,})")
+    return sampled
 
 
-def build_dataset(args, mins, maxs):
+def build_dataset(args):
     from eval_anomaly import SCENARIO_MAKERS
 
-    # ── 정상 시퀀스: CSV 실데이터만 사용 (먼저 로드) ────────────
+    # ── 정상 시퀀스: CSV 실데이터 로드 (raw) ────────────────────
     csv_candidates = [
+        f"{DATA_DIR}/ais_preprocessed.csv",
+        f"{DATA_DIR}/ais-2024-01-01_preprocessed.csv",
+        f"{DATA_DIR}/ais-2025-01-25_preprocessed.csv",
+        f"{DATA_DIR}/ais-2025-12-31_preprocessed.csv",
+        # 현재 디렉터리 폴백 (이전 방식 호환)
         "ais_preprocessed.csv",
-        "ais-2024-01-01_preprocessed.csv",
         "ais-2025-01-25_preprocessed.csv",
-        "ais-2025-12-31_preprocessed.csv",
     ]
-    normal_seqs = []
+    raw_normal = []
     for cand in csv_candidates:
-        normal_seqs = load_normal_from_csv(
-            cand, mins, maxs,
+        raw_normal = load_normal_from_csv(
+            cand,
             max_seqs=args.n_normal,
             max_mmsi=args.max_mmsi,
         )
-        if normal_seqs:
+        if raw_normal:
             break
 
-    if not normal_seqs:
-        print("  [오류] 정상 CSV 데이터를 찾을 수 없습니다. CSV 파일을 ml/ 폴더에 확인하세요.")
+    if not raw_normal:
+        print("  [오류] 정상 CSV 데이터를 찾을 수 없습니다. CSV 파일을 ml/data/ 폴더에 확인하세요.")
         sys.exit(1)
+
+    # ── 스케일러: 정상 데이터에서 직접 계산 후 저장 ─────────────
+    mins, maxs = compute_scaler(raw_normal)
+    save_scaler(mins, maxs, SCALER_SUP)
+    print(f"  [스케일러] 정상 데이터 기반으로 계산 → {SCALER_SUP}")
+
+    normal_seqs = [scale_seq(seq, mins, maxs) for seq in raw_normal]
 
     # ── 이상 시퀀스 생성 (홀드아웃 제외, 정상 수에 비례) ─────────
     anom_makers = [(name, maker) for name, maker, is_anom, is_holdout
@@ -653,7 +676,9 @@ def export_onnx(model, name: str, device):
     wrapped = SigmoidWrapper(model).to(device)
     wrapped.eval()
     dummy = torch.zeros(1, SEQ_LEN, N_FEAT, device=device)
-    path  = f"model_sup_{name}.onnx"
+    model_out_dir = os.path.join(OUTPUT_DIR, f"sup_{name}")
+    os.makedirs(model_out_dir, exist_ok=True)
+    path  = os.path.join(model_out_dir, f"model_sup_{name}.onnx")
     torch.onnx.export(
         wrapped, dummy, path,
         input_names=["x"],
@@ -725,7 +750,9 @@ def run_model(name: str, model: nn.Module, train_loader, val_loader, args, devic
     print(f"  ONNX 저장: {onnx_path}")
 
     # 임계값 저장
-    thr_path = f"threshold_sup_{name}.txt"
+    model_out_dir = os.path.join(OUTPUT_DIR, f"sup_{name}")
+    os.makedirs(model_out_dir, exist_ok=True)
+    thr_path = os.path.join(model_out_dir, f"threshold_sup_{name}.txt")
     with open(thr_path, "w") as f:
         f.write(f"{best_thr:.6f}\n")
         f.write(f"# model: {name}\n")
@@ -792,11 +819,13 @@ def main():
     parser.add_argument("--n_layers",     type=int,   default=DEFAULTS["n_layers"])
     parser.add_argument("--dropout",      type=float, default=DEFAULTS["dropout"])
     parser.add_argument("--weight_decay", type=float, default=DEFAULTS["weight_decay"])
-    parser.add_argument("--scaler",       type=str,   default=SCALER_SOURCE,
-                        help="재사용할 스케일러 JSON 경로")
     parser.add_argument("--device",       type=str,   default="auto",
                         help="cuda / cpu / auto")
     args = parser.parse_args()
+
+    # 출력/데이터 디렉터리 생성
+    os.makedirs(OUTPUT_DIR, exist_ok=True)
+    os.makedirs(DATA_DIR,   exist_ok=True)
 
     # 디바이스 설정
     if args.device == "auto":
@@ -805,23 +834,9 @@ def main():
         device = torch.device(args.device)
     print(f"[디바이스] {device}")
 
-    # 스케일러 로드
-    if not os.path.exists(args.scaler):
-        # 대체 스케일러 탐색
-        for alt in ["scaler_tranad.json", "scaler_conv1d.json", "scaler.json"]:
-            if os.path.exists(alt):
-                args.scaler = alt
-                break
-        else:
-            print(f"[오류] 스케일러 파일을 찾을 수 없습니다: {args.scaler}")
-            print("  먼저 비지도 모델을 학습하거나 --scaler 옵션으로 경로를 지정하세요.")
-            sys.exit(1)
-    print(f"[스케일러] {args.scaler}")
-    mins, maxs = load_scaler(args.scaler)
-
-    # 데이터 준비
+    # 데이터 준비 (스케일러는 CSV에서 자동 계산)
     print("\n[데이터 준비]")
-    X_t, y_t = build_dataset(args, mins, maxs)
+    X_t, y_t = build_dataset(args)
     train_loader, val_loader = make_loaders(X_t, y_t, args.batch, args.val_ratio)
     print(f"  train: {len(train_loader.dataset):,}  val: {len(val_loader.dataset):,}")
 


### PR DESCRIPTION
## 변경 사항

### ML 디렉터리 구조 정리
- `ml/data/` : CSV 입력 데이터 전용
- `ml/output/{model}/` : 모델별 서브디렉터리 (onnx, threshold, eval_result)
- `ml/output/scaler_sup.json` : 지도학습 전용 스케일러

### 지도학습 스케일러 독립화
- 기존: dcdetect 비지도 모델 스케일러 재사용
- 변경: 학습 CSV 데이터에서 직접 min/max 계산 후 저장
- `--scaler` 인자 제거 (자동 생성)

### CI 수정
- `tqdm` 패키지 추가
- `ais_ids.cpp` 컴파일 제거 (`ocpn_plugin.h` 의존 → cppcheck으로 대체)

## 마이그레이션
기존 CSV 파일을 `ml/data/`로 이동 필요
```bash
mkdir -p ml/data
mv ml/*.csv ml/data/