### PR TITLE
ais_ids: 시퀀스 gap 처리 추가 (dt > 600s 리셋, dt < 1s 스킵)

### DIFF
--- a/ais_ids_pi/src/ais_ids.cpp
+++ b/ais_ids_pi/src/ais_ids.cpp
@@ -96,6 +96,17 @@ void ais_ids::to_snapshot(AISTarget &target)
 
         float dt = (float)(cur.rxTime - prev.rxTime);
 
+        // gap 처리: dt > 600초(10분)이면 시퀀스 연속성 깨짐 → deque 리셋 후 스킵
+        if (dt > 600.0f) {
+            ais_ml->ClearSequence(target.mmsi);
+            return;
+        }
+
+        // dt 이상값 처리: 너무 작으면(1초 미만) 동일 메시지 중복 수신으로 간주 → 스킵
+        if (dt < 1.0f) {
+            return;
+        }
+
         double dLat = (cur.lat - prev.lat) * M_PI / 180.0;
         double dLon = (cur.lon - prev.lon) * M_PI / 180.0;
         double a    = std::sin(dLat/2) * std::sin(dLat/2)


### PR DESCRIPTION
- dt > 600초: 신호 단절로 간주, ML 시퀀스 리셋 후 스킵
- dt < 1초: 중복 수신으로 간주, 스킵
- 파일 재생 등 비정상 타이밍 입력 시 오탐 방지