### PR TITLE
feat(automation): MLflow + Sheets + Notion + Slack/Discord + GitHub 릴리즈 자동화 파이프라인

### DIFF
--- a/.github/workflows/daily_pipeline.yml
+++ b/.github/workflows/daily_pipeline.yml
@@ -1,0 +1,77 @@
+name: Daily Pipeline (Self-Hosted)
+
+# 매일 02:00 KST (전날 17:00 UTC) 자동 실행
+# 자신의 Windows 머신에 self-hosted runner를 등록해야 함
+# 등록 방법: GitHub 레포 → Settings → Actions → Runners → New self-hosted runner
+
+on:
+  schedule:
+    - cron: "0 17 * * *"   # UTC 17:00 = KST 02:00
+  workflow_dispatch:        # 수동 실행
+    inputs:
+      models:
+        description: "학습할 모델 (공백 구분, 예: conv1d tranad dcdetect)"
+        required: false
+        default: "conv1d tranad dcdetect"
+      epochs:
+        description: "에포크 수"
+        required: false
+        default: "10"
+      release:
+        description: "릴리즈 생성 여부 (true/false)"
+        required: false
+        default: "false"
+      tag:
+        description: "릴리즈 태그 (release=true 일 때)"
+        required: false
+        default: ""
+
+jobs:
+  run-pipeline:
+    name: AIS 학습 파이프라인
+    runs-on: self-hosted        # ← Windows 로컬 머신에 등록된 runner
+
+    env:
+      MLFLOW_TRACKING_URI:      ${{ secrets.MLFLOW_TRACKING_URI }}
+      SLACK_BOT_TOKEN:          ${{ secrets.SLACK_BOT_TOKEN }}
+      SLACK_CHANNEL:            ${{ secrets.SLACK_CHANNEL }}
+      DISCORD_WEBHOOK_URL:      ${{ secrets.DISCORD_WEBHOOK_URL }}
+      NOTION_API_KEY:           ${{ secrets.NOTION_API_KEY }}
+      NOTION_DATABASE_ID:       ${{ secrets.NOTION_DATABASE_ID }}
+      GSHEETS_SPREADSHEET_ID:   ${{ secrets.GSHEETS_SPREADSHEET_ID }}
+      GITHUB_TOKEN:             ${{ secrets.GH_PAT }}
+      GITHUB_REPO:              ${{ github.repository }}
+
+    steps:
+      - name: 코드 체크아웃
+        uses: actions/checkout@v4
+
+      - name: Python 의존성 설치
+        run: |
+          pip install -r automation/requirements.txt
+
+      - name: 파이프라인 실행
+        run: |
+          $models  = "${{ github.event.inputs.models || 'conv1d tranad dcdetect' }}"
+          $epochs  = "${{ github.event.inputs.epochs || '10' }}"
+          $release = "${{ github.event.inputs.release || 'false' }}"
+          $tag     = "${{ github.event.inputs.tag || '' }}"
+
+          $cmd = "python automation/pipeline_runner.py --models $models --epochs $epochs"
+          if ($release -eq "true" -and $tag -ne "") {
+            $cmd += " --release --tag $tag"
+          }
+          Invoke-Expression $cmd
+
+      - name: 실패 시 GitHub Issue 생성
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `[자동] Daily Pipeline 실패 — ${new Date().toISOString().slice(0,10)}`,
+              body: `## 실패 정보\n- 워크플로: daily_pipeline.yml\n- Run ID: ${context.runId}\n- [로그 보기](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})\n\n자동 생성된 이슈입니다.`,
+              labels: ["bug", "automation"]
+            });

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,49 @@
+name: Release
+
+# v* 태그 푸시 시 자동 릴리즈 (self-hosted runner 필요)
+# 사용: git tag v1.0.0 && git push origin v1.0.0
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "릴리즈 태그 (예: v1.0.0)"
+        required: true
+      models:
+        description: "포함할 모델 (공백 구분)"
+        required: false
+        default: "conv1d tranad dcdetect"
+
+jobs:
+  create-release:
+    name: GitHub 릴리즈 생성
+    runs-on: self-hosted
+
+    env:
+      SLACK_BOT_TOKEN:        ${{ secrets.SLACK_BOT_TOKEN }}
+      SLACK_CHANNEL:          ${{ secrets.SLACK_CHANNEL }}
+      DISCORD_WEBHOOK_URL:    ${{ secrets.DISCORD_WEBHOOK_URL }}
+      NOTION_API_KEY:         ${{ secrets.NOTION_API_KEY }}
+      NOTION_DATABASE_ID:     ${{ secrets.NOTION_DATABASE_ID }}
+      GSHEETS_SPREADSHEET_ID: ${{ secrets.GSHEETS_SPREADSHEET_ID }}
+      GITHUB_TOKEN:           ${{ secrets.GH_PAT }}
+      GITHUB_REPO:            ${{ github.repository }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Python 의존성 설치
+        run: pip install -r automation/requirements.txt
+
+      - name: 릴리즈 생성
+        run: |
+          $tag    = "${{ github.ref_name || github.event.inputs.tag }}"
+          $models = "${{ github.event.inputs.models || 'conv1d tranad dcdetect' }}"
+          python automation/pipeline_runner.py `
+            --models $models `
+            --eval-only `
+            --release `
+            --tag $tag

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,19 @@ ml/**/*.pdf
 
 aivdm_gen/*.csv
 
+# ── automation/ ─────────────────────────────────────────────────────────────
+# 실제 환경변수 (절대 커밋 금지)
+automation/.env
+
+# Google Sheets 서비스 계정 JSON 키
+automation/credentials.json
+
+# MLflow 로컬 DB / 실험 디렉토리
+mlflow.db
+mlruns/
+_test_mlruns/
+_test_output/
+
 # 시크릿 / 설정
 ml/notify_config.json
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,8 @@ Before pushing code or when asked to push, always check the following first:
 
 1. **README.md / ml/README.md** — Verify that any changed features, paths, or options are reflected in the docs. Update outdated content before pushing.
 2. **Source code comments** — Verify that comments in modified functions/classes match current behavior. Remove or fix any stale comments.
+3. **automation/** — If pipeline paths, model names, or env vars changed, update `automation/config.py` and `automation/README.md` accordingly.
+4. **Secrets hygiene** — Never commit real tokens/keys. `.env.example` must only contain placeholder values (e.g. `xoxb-your-token-here`), not real credentials.
 
 ---
 
@@ -29,6 +31,17 @@ JB-Pirate-King/
 │   ├── download_ais.py    # AIS data downloader
 │   ├── eval_rule_gen.py   # Rule-based evaluation generator
 │   └── deploy/            # Deployment model/scaler/threshold files
+├── automation/            # 자동화 파이프라인 레이어 ★ (신규)
+│   ├── pipeline_runner.py # 메인 오케스트레이터 (ml/pipeline.py 래핑)
+│   ├── mlflow_tracker.py  # MLflow 실험 추적
+│   ├── notify.py          # Slack + Discord 알림
+│   ├── sheets_tracker.py  # Google Sheets 결과 기록
+│   ├── notion_reporter.py # Notion 자동 문서화
+│   ├── github_release.py  # GitHub Release 자동화
+│   ├── config.py          # 환경변수 중앙 관리
+│   ├── requirements.txt   # automation 의존성
+│   ├── .env.example       # 토큰/키 예시 (실제값 절대 커밋 금지)
+│   └── README.md          # 상세 설정 가이드
 ├── ais_ids_pi/            # OpenCPN plugin (C++)
 │   └── src/ais_ids.cpp    # Plugin main source
 ├── s-c/                   # Local server + GUI
@@ -259,6 +272,75 @@ Copy model.onnx / scaler.json / threshold.txt to ais_ids_pi/data/
 | Version | Date | Models | Notes |
 |---|---|---|---|
 | v0.1.0 | — | conv1d, tranad, dcdetect | Initial release (1-day training data) |
+
+---
+
+## Automation Pipeline
+
+전체 ML 파이프라인을 자동화하는 레이어. `ml/pipeline.py`를 수정하지 않고 래핑하는 방식.
+
+### 아키텍처 다이어그램
+FigJam: https://www.figma.com/board/cyTCcQ6zhHlVIrcjSBufli
+
+### 빠른 사용법
+
+```bash
+# 의존성 설치
+pip install -r automation/requirements.txt
+
+# MLflow 서버 (로컬)
+mlflow server --host 0.0.0.0 --port 5000   # UI: http://localhost:5000
+
+# 학습 + 평가 + 전체 알림/리포팅
+python automation/pipeline_runner.py --models conv1d tranad dcdetect --epochs 10
+
+# 학습 + 릴리즈 생성
+python automation/pipeline_runner.py --models conv1d tranad --epochs 10 --release --tag v0.2.0
+
+# 평가만 (이미 학습된 모델)
+python automation/pipeline_runner.py --eval-only --models conv1d
+```
+
+### 통합 서비스 및 설정 위치
+
+| 서비스 | 모듈 | 설정 키 (.env) |
+|--------|------|---------------|
+| MLflow | `mlflow_tracker.py` | `MLFLOW_TRACKING_URI` |
+| Slack | `notify.py` | `SLACK_BOT_TOKEN`, `SLACK_CHANNEL` |
+| Discord | `notify.py` | `DISCORD_WEBHOOK_URL` |
+| Notion | `notion_reporter.py` | `NOTION_API_KEY`, `NOTION_DATABASE_ID` |
+| Google Sheets | `sheets_tracker.py` | `GSHEETS_SPREADSHEET_ID`, `GSHEETS_CREDS_FILE` |
+| GitHub Release | `github_release.py` | `GITHUB_TOKEN`, `GITHUB_REPO` |
+
+환경변수는 `automation/.env` (git 제외) 또는 GitHub Secrets에 저장.
+설정 가이드: `automation/README.md`
+
+### GitHub Actions 워크플로
+
+| 파일 | 트리거 | Runner | 역할 |
+|------|--------|--------|------|
+| `ci.yml` | Push/PR → main, develop | ubuntu-latest | 문법검사 + smoke test |
+| `daily_pipeline.yml` | 매일 02:00 KST, 수동 | self-hosted (로컬 Windows) | 학습 + 평가 + 알림 |
+| `release.yml` | `v*` 태그 Push, 수동 | self-hosted | 릴리즈 생성 + 파일 첨부 |
+
+> `daily_pipeline.yml`과 `release.yml`은 `D:\ais_data` 데이터가 있는 로컬 머신에 self-hosted runner 등록 필요.
+
+---
+
+## Available MCP Tools (Claude Code 세션 내)
+
+이 프로젝트에서 Claude Code가 사용할 수 있는 MCP 연동 서비스:
+
+| MCP | 주요 기능 | 언제 사용 |
+|-----|-----------|-----------|
+| **GitHub** | PR/이슈 생성, 파일 read/write, 릴리즈 | 브랜치 관리, PR 생성, 코드 리뷰 |
+| **Notion** | 페이지 생성/수정, DB 쿼리 | 실험 결과 문서화, 작업 로그 |
+| **Google Sheets** | 시트 생성/수정, 데이터 조회 | 성능 비교표, 데이터 트래킹 |
+| **Slack** | 메시지 전송, 채널 검색 | 팀 알림, 진행 상황 공유 |
+| **Figma** | FigJam 다이어그램, 디자인 생성 | 아키텍처 다이어그램 |
+| **Context7** | 라이브러리 최신 문서 조회 | MLflow/PyTorch API 확인 |
+
+> Python 자동화 스크립트(`automation/*.py`)는 MCP가 아니라 각 서비스의 Python SDK를 직접 사용함.
 
 ---
 

--- a/automation/.env.example
+++ b/automation/.env.example
@@ -25,7 +25,7 @@ NOTION_DATABASE_ID=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 GSHEETS_CREDS_FILE=automation/credentials.json
 # Sheets URL https://docs.google.com/spreadsheets/d/{SPREADSHEET_ID}/
 GSHEETS_SPREADSHEET_ID=your-spreadsheet-id-here
-GSHEETS_SHEET_NAME=pipeline_results
+# 시트명은 코드에서 고정값으로 관리 (🤖 ML 모델 성능 / 🔄 실행 로그)
 
 # ─── GitHub ───────────────────────────────────────────────────────────────────
 # GitHub → Settings → Developer settings → Personal access tokens

--- a/automation/.env.example
+++ b/automation/.env.example
@@ -1,5 +1,8 @@
 # ─── MLflow ───────────────────────────────────────────────────────────────────
-MLFLOW_TRACKING_URI=http://localhost:5000
+# SQLite 로컬 (기본값, 서버 불필요)
+MLFLOW_TRACKING_URI=sqlite:///mlflow.db
+# 외부 서버 사용 시:
+# MLFLOW_TRACKING_URI=http://localhost:5000
 MLFLOW_EXPERIMENT=ais-anomaly-detection
 
 # ─── Slack ────────────────────────────────────────────────────────────────────

--- a/automation/.env.example
+++ b/automation/.env.example
@@ -1,0 +1,36 @@
+# ─── MLflow ───────────────────────────────────────────────────────────────────
+MLFLOW_TRACKING_URI=http://localhost:5000
+MLFLOW_EXPERIMENT=ais-anomaly-detection
+
+# ─── Slack ────────────────────────────────────────────────────────────────────
+# Slack Bot Token (xoxb-...) — Slack 앱 생성 후 발급
+SLACK_BOT_TOKEN=xoxb-your-token-here
+SLACK_CHANNEL=#ais-training-alerts
+
+# ─── Discord ─────────────────────────────────────────────────────────────────
+# Discord 서버 → 채널 설정 → 웹후크 → 웹후크 URL 복사
+DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/your-webhook-id/your-webhook-token
+
+# ─── Notion ───────────────────────────────────────────────────────────────────
+# Notion → Settings → Integrations → 새 통합 생성 → Internal Integration Token
+NOTION_API_KEY=secret_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+# 결과를 기록할 Notion Database 페이지 ID (URL에서 추출)
+NOTION_DATABASE_ID=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+# ─── Google Sheets ────────────────────────────────────────────────────────────
+# Google Cloud Console → 서비스 계정 → JSON 키 다운로드
+GSHEETS_CREDS_FILE=automation/credentials.json
+# Sheets URL https://docs.google.com/spreadsheets/d/{SPREADSHEET_ID}/
+GSHEETS_SPREADSHEET_ID=your-spreadsheet-id-here
+GSHEETS_SHEET_NAME=pipeline_results
+
+# ─── GitHub ───────────────────────────────────────────────────────────────────
+# GitHub → Settings → Developer settings → Personal access tokens
+GITHUB_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+GITHUB_REPO=heahgo/JB-Pirate-King
+
+# ─── Pipeline 경로 ────────────────────────────────────────────────────────────
+BASE_DIR=D:\
+DATA_FILE=D:\ais_data\preprocessed\2025\ais_preprocessed_2025.csv
+MODELS_DIR=D:\ais_models
+OUTPUT_DIR=D:\ais_output\pipeline

--- a/automation/README.md
+++ b/automation/README.md
@@ -1,0 +1,220 @@
+# automation/ — JB-Pirate-King 자동화 파이프라인
+
+AIS 이상탐지 ML 시스템의 전체 자동화 레이어.
+**MLflow**, **Google Sheets**, **Notion**, **Slack**, **Discord**, **GitHub Actions**를 통합하여
+학습 → 평가 → 리포팅 → 알림 → 릴리즈를 자동화한다.
+
+---
+
+## 아키텍처 다이어그램
+
+> FigJam에서 전체 파이프라인 아키텍처 확인:
+> **[JB-Pirate-King AIS 이상탐지 자동화 파이프라인](https://www.figma.com/board/cyTCcQ6zhHlVIrcjSBufli)**
+
+```
+[Trigger Layer]
+  GitHub Actions (Cron 02:00 KST / Push) → workflow_dispatch (수동)
+
+[Data Layer]
+  download_ais.py → preprocess.py → D:\ais_data\preprocessed\
+                  ↘ Google Sheets (data_coverage 시트에 기록)
+
+[ML Layer]
+  pipeline.py (9 모델 학습) ↔ MLflow Tracking (Params/Metrics/Artifacts)
+                            → eval_anomaly.py (32 시나리오 평가)
+                            → MLflow Registry (Staging → Production)
+
+[Report Layer]
+  eval 결과 → Google Sheets (pipeline_results 시트)
+           → Notion Database (실험 페이지 자동 생성)
+
+[Notification Layer]
+  완료/실패 → Slack (#ais-training-alerts)
+           → Discord (Webhook)
+  실패 시  → GitHub Issue 자동 생성
+
+[Deploy Layer]
+  MLflow Registry Promotion → GitHub Release (ONNX + Scaler + Threshold)
+                           → ais_ids_pi/data/ (플러그인 배포)
+```
+
+---
+
+## 디렉토리 구조
+
+```
+automation/
+├── README.md           # 이 문서
+├── __init__.py
+├── requirements.txt    # Python 의존성
+├── .env.example        # 환경변수 예시
+│
+├── config.py           # 환경변수 로딩 (모든 모듈이 임포트)
+├── mlflow_tracker.py   # MLflow 실험 추적 통합
+├── notify.py           # Slack + Discord 알림
+├── sheets_tracker.py   # Google Sheets 결과 기록
+├── notion_reporter.py  # Notion 자동 문서화
+├── github_release.py   # GitHub 릴리즈 자동화
+└── pipeline_runner.py  # 메인 오케스트레이터 (진입점)
+
+.github/workflows/
+├── ci.yml              # 기존: Push/PR 시 문법 검사 + smoke test
+├── daily_pipeline.yml  # 새로 추가: 일일 학습 파이프라인 (self-hosted)
+└── release.yml         # 새로 추가: 태그 기반 GitHub 릴리즈 자동화
+```
+
+---
+
+## 빠른 시작
+
+### 1. 의존성 설치
+
+```bash
+pip install -r automation/requirements.txt
+```
+
+### 2. 환경변수 설정
+
+```bash
+cp automation/.env.example automation/.env
+# .env 파일을 열고 각 서비스의 토큰/키를 입력
+```
+
+### 3. MLflow 서버 실행 (로컬)
+
+```bash
+mlflow server --host 0.0.0.0 --port 5000
+# 브라우저: http://localhost:5000
+```
+
+### 4. 파이프라인 실행
+
+```bash
+# 기본 실행 (conv1d tranad dcdetect, 10 에포크)
+python automation/pipeline_runner.py --models conv1d tranad dcdetect --epochs 10
+
+# 학습 없이 평가만
+python automation/pipeline_runner.py --eval-only --models conv1d
+
+# 학습 + 릴리즈 생성
+python automation/pipeline_runner.py --models conv1d tranad --epochs 10 --release --tag v0.2.0
+
+# 이미 학습된 모델 스킵
+python automation/pipeline_runner.py --models conv1d tranad dcdetect --skip_trained
+```
+
+---
+
+## 각 모듈 설명
+
+### `config.py`
+모든 환경변수를 한 곳에서 관리. `.env` 파일 또는 OS 환경변수에서 로딩.
+
+### `mlflow_tracker.py`
+`ml/pipeline.py` 실행 결과를 MLflow에 기록하는 래퍼.
+- 실험(Experiment): `ais-anomaly-detection`
+- 런(Run)마다: 파라미터(epochs, seq_len, n_features), 메트릭(DR, FPR), 아티팩트(ONNX, CSV)
+- `patch_pipeline_with_mlflow(model, epochs)` — 이미 실행된 결과 CSV를 읽어 MLflow에 소급 기록
+
+### `notify.py`
+Slack + Discord 이중 알림.
+| 이벤트 | Slack | Discord |
+|--------|-------|---------|
+| 학습 완료 | ✅ Block 메시지 | ✅ Embed |
+| 파이프라인 실패 | ❌ 오류 코드 포함 | ❌ Embed |
+| 릴리즈 생성 | 🚀 릴리즈 URL | 🚀 링크 |
+| 데이터 업데이트 | 📦 커버리지 | 📦 커버리지 |
+
+### `sheets_tracker.py`
+Google Sheets에 두 시트를 관리:
+- `pipeline_results` — 모델별 실험 결과 (timestamp, model, DR, FPR, MLflow run_id)
+- `data_coverage` — 전처리 데이터 날짜 범위 추적
+
+### `notion_reporter.py`
+학습 완료 시 Notion Database에 실험 페이지 자동 생성.
+페이지 속성: Model, Status, Train DR, Holdout DR, FP Rate, Epochs, Date, Release URL
+
+### `github_release.py`
+GitHub Release 자동 생성 + 모델 파일 첨부.
+- `D:\ais_models\{model}\model_{model}.onnx` 를 찾아 첨부
+- 비교 리포트(comparison_*.txt/csv)도 함께 첨부
+- Release notes 자동 생성 (모델별 DR 포함)
+
+### `pipeline_runner.py`
+위 모든 모듈을 순서대로 호출하는 메인 진입점.
+실행 순서: `pipeline.py` → MLflow 기록 → Sheets 기록 → Notion 생성 → 알림 → (선택) 릴리즈 생성
+
+---
+
+## GitHub Actions 설정
+
+### Secrets 등록 (GitHub 레포 → Settings → Secrets)
+
+| Secret 이름 | 값 |
+|-------------|-----|
+| `SLACK_BOT_TOKEN` | Slack Bot OAuth Token (xoxb-...) |
+| `SLACK_CHANNEL` | `#ais-training-alerts` |
+| `DISCORD_WEBHOOK_URL` | Discord 웹훅 URL |
+| `NOTION_API_KEY` | Notion Internal Integration Token |
+| `NOTION_DATABASE_ID` | 결과 DB 페이지 ID |
+| `GSHEETS_SPREADSHEET_ID` | Google Sheets ID |
+| `GH_PAT` | GitHub Personal Access Token (write:packages, repo) |
+| `MLFLOW_TRACKING_URI` | `http://localhost:5000` (self-hosted runner 기준) |
+
+### Self-Hosted Runner 등록 (학습용)
+
+학습은 로컬 Windows 머신(D:\ 데이터 있는 곳)에서 실행되어야 하므로 self-hosted runner를 등록한다.
+
+```powershell
+# GitHub 레포 → Settings → Actions → Runners → New self-hosted runner → Windows
+# 안내에 따라 runner 설치 후:
+.\run.cmd
+```
+
+`daily_pipeline.yml`과 `release.yml`은 `runs-on: self-hosted`로 설정되어 있음.
+
+### 워크플로 파일
+
+| 파일 | 트리거 | Runner | 역할 |
+|------|--------|--------|------|
+| `ci.yml` | Push to main/develop, PR | ubuntu-latest | 문법 검사, smoke test |
+| `daily_pipeline.yml` | 매일 02:00 KST, 수동 | self-hosted | 학습 + 평가 + 알림 |
+| `release.yml` | `v*` 태그 Push, 수동 | self-hosted | 릴리즈 생성 + 파일 첨부 |
+
+---
+
+## MLflow 실험 구조
+
+```
+ais-anomaly-detection (Experiment)
+├── conv1d_ep10 (Run)
+│   ├── params: {model, epochs, seq_len, n_features}
+│   ├── metrics: {detection_rate, fp_rate, holdout_detection_rate}
+│   └── artifacts: {model_conv1d.onnx, scaler_conv1d.json, conv1d_TIMESTAMP.csv}
+├── tranad_ep10 (Run)
+│   └── ...
+└── dcdetect_ep10 (Run)
+    └── ...
+```
+
+---
+
+## 서비스별 초기 설정 가이드
+
+### Slack 앱 생성
+1. https://api.slack.com/apps → Create New App
+2. OAuth & Permissions → Bot Token Scopes: `chat:write`, `files:write`
+3. Install to Workspace → Bot User OAuth Token 복사
+
+### Discord 웹훅
+1. 서버 → 채널 설정 → 연동 → 웹훅 → 새 웹훅 → URL 복사
+
+### Notion 통합
+1. https://www.notion.so/my-integrations → 새 통합 생성
+2. Internal Integration Token 복사
+3. 결과 Database 페이지 → ... → 연결 → 통합 추가
+
+### Google Sheets 서비스 계정
+1. Google Cloud Console → IAM → 서비스 계정 생성
+2. JSON 키 다운로드 → `automation/credentials.json`으로 저장
+3. Sheets 파일에 서비스 계정 이메일을 편집자로 공유

--- a/automation/__init__.py
+++ b/automation/__init__.py
@@ -1,0 +1,1 @@
+# automation package

--- a/automation/_test_run.py
+++ b/automation/_test_run.py
@@ -159,8 +159,11 @@ try:
         report("Google Sheets", True, "스킵 (SPREADSHEET_ID 미설정)")
     else:
         s = SheetsTracker()
-        s.log_result(TEST_MODEL, TEST_EPOCHS, 74.8, 71.2, 1.0, run_id)
-        report("Google Sheets", True, "기록 완료 → 🤖 ML 모델 성능 시트")
+        if s._disabled:
+            report("Google Sheets", False, "연결 실패 (credentials.json 없음 또는 권한 오류)")
+        else:
+            s.log_result(TEST_MODEL, TEST_EPOCHS, 74.8, 71.2, 1.0, run_id)
+            report("Google Sheets", True, "기록 완료 → 🤖 ML 모델 성능 시트")
 except Exception as e:
     report("Google Sheets", False, str(e))
 

--- a/automation/_test_run.py
+++ b/automation/_test_run.py
@@ -160,7 +160,7 @@ try:
     else:
         s = SheetsTracker()
         s.log_result(TEST_MODEL, TEST_EPOCHS, 74.8, 71.2, 1.0, run_id)
-        report("Google Sheets", True, "기록 완료")
+        report("Google Sheets", True, "기록 완료 → 🤖 ML 모델 성능 시트")
 except Exception as e:
     report("Google Sheets", False, str(e))
 

--- a/automation/_test_run.py
+++ b/automation/_test_run.py
@@ -1,0 +1,220 @@
+"""
+automation/_test_run.py
+파이프라인 시범 가동 스크립트.
+실제 학습 없이 더미 CSV를 생성하고 전체 자동화 체인을 한 바퀴 돌린다.
+실행: python automation/_test_run.py
+"""
+import sys, os, csv, tempfile, time, shutil
+sys.stdout.reconfigure(encoding="utf-8")
+
+# ── 프로젝트 루트 기준 임포트
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, ROOT)
+
+PASS = "✅"
+FAIL = "❌"
+SKIP = "⏭ "
+
+results = []
+
+def report(name, ok, note=""):
+    icon = PASS if ok else (SKIP if "스킵" in str(note) else FAIL)
+    line = f"  {icon} {name:<30} {note}"
+    print(line)
+    results.append((name, ok, note))
+
+
+# ────────────────────────────────────────────────────
+# 1) 환경변수 / config 로딩
+# ────────────────────────────────────────────────────
+print("\n[1] config 로딩")
+from automation.config import (
+    MLFLOW_TRACKING_URI, SLACK_BOT_TOKEN, DISCORD_WEBHOOK_URL,
+    NOTION_API_KEY, GSHEETS_SPREADSHEET_ID, GITHUB_TOKEN,
+)
+print(f"  MLflow URI  : {MLFLOW_TRACKING_URI}")
+print(f"  Slack       : {'설정됨' if SLACK_BOT_TOKEN else '미설정'}")
+print(f"  Discord     : {'설정됨' if DISCORD_WEBHOOK_URL else '미설정'}")
+print(f"  Notion      : {'설정됨' if NOTION_API_KEY else '미설정'}")
+print(f"  Sheets      : {'설정됨' if GSHEETS_SPREADSHEET_ID else '미설정'}")
+print(f"  GitHub      : {'설정됨' if GITHUB_TOKEN else '미설정'}")
+report("config 로딩", True)
+
+
+# ────────────────────────────────────────────────────
+# 2) 더미 eval CSV 생성 (pipeline.py 출력 시뮬레이션)
+# ────────────────────────────────────────────────────
+print("\n[2] 더미 eval CSV 생성")
+TEST_MODEL  = "conv1d"
+TEST_EPOCHS = 3
+DUMMY_OUTPUT_DIR = os.path.join(ROOT, "_test_output")
+os.makedirs(DUMMY_OUTPUT_DIR, exist_ok=True)
+
+ts = time.strftime("%Y%m%d_%H%M%S")
+dummy_csv = os.path.join(DUMMY_OUTPUT_DIR, f"{TEST_MODEL}_{ts}.csv")
+
+rows = [
+    # group, scenario, detection_rate
+    ("Basic", "cog_hdg_mismatch",   85.0),
+    ("Basic", "anchored_movement",  78.0),
+    ("Basic", "speed_anomaly",      92.0),
+    ("Basic", "position_jump",      88.0),
+    ("FN",    "fn_scenario_1",      60.0),
+    ("FN",    "fn_scenario_2",      55.0),
+    ("D",     "d_evasion_1",        70.0),
+    ("E",     "e_evasion_1",        65.0),
+    ("F",     "f_holdout_1",        72.0),  # holdout
+    ("F",     "f_holdout_2",        68.0),  # holdout
+    ("G",     "g_holdout_1",        74.0),  # holdout
+    ("G",     "g_holdout_2",        71.0),  # holdout
+]
+with open(dummy_csv, "w", newline="", encoding="utf-8") as f:
+    w = csv.writer(f)
+    w.writerow(["group", "scenario", "detection_rate", "fp_rate"])
+    for g, s, dr in rows:
+        w.writerow([g, s, dr, 1.0])
+
+# 더미 comparison CSV
+cmp_csv = os.path.join(DUMMY_OUTPUT_DIR, f"comparison_{ts}.csv")
+with open(cmp_csv, "w", newline="", encoding="utf-8") as f:
+    w = csv.writer(f)
+    w.writerow(["model", "train_dr", "holdout_dr", "fp_rate"])
+    w.writerow([TEST_MODEL, 74.8, 71.2, 1.0])
+
+print(f"  {PASS} 더미 CSV: {dummy_csv}")
+report("더미 CSV 생성", True, os.path.basename(dummy_csv))
+
+
+# ────────────────────────────────────────────────────
+# 3) MLflow 실험 기록 (파일 기반, 서버 불필요)
+# ────────────────────────────────────────────────────
+print("\n[3] MLflow 실험 기록")
+try:
+    import mlflow
+    mlflow_dir = os.path.join(ROOT, "_test_mlruns")
+    mlflow.set_tracking_uri(f"file:///{mlflow_dir.replace(os.sep, '/')}")
+    mlflow.set_experiment("ais-anomaly-detection-test")
+
+    with mlflow.start_run(run_name=f"{TEST_MODEL}_ep{TEST_EPOCHS}_test") as run:
+        mlflow.set_tag("model_name", TEST_MODEL)
+        mlflow.log_params({"model": TEST_MODEL, "epochs": TEST_EPOCHS, "seq_len": 10, "n_features": 12})
+
+        # 에포크별 메트릭 시뮬레이션
+        for ep in range(1, TEST_EPOCHS + 1):
+            mlflow.log_metrics({"train_loss": 0.1 / ep, "val_loss": 0.12 / ep}, step=ep)
+
+        mlflow.log_metrics({"detection_rate": 74.8, "holdout_dr": 71.2, "fp_rate": 1.0})
+        mlflow.log_artifact(dummy_csv)
+
+        run_id = run.info.run_id
+
+    report("MLflow 기록", True, f"run_id={run_id[:8]}…  (file://_test_mlruns)")
+    print(f"  💡 UI 확인: mlflow ui --backend-store-uri file:///{mlflow_dir.replace(os.sep, '/')}")
+except Exception as e:
+    report("MLflow 기록", False, str(e))
+    run_id = ""
+
+
+# ────────────────────────────────────────────────────
+# 4) Slack 알림
+# ────────────────────────────────────────────────────
+print("\n[4] Slack 알림")
+try:
+    from automation.notify import Notifier
+    n = Notifier()
+    if not SLACK_BOT_TOKEN:
+        report("Slack 알림", True, "스킵 (토큰 미설정)")
+    else:
+        n.training_complete(TEST_MODEL, dr=74.8, holdout=71.2, fp=1.0,
+                            elapsed_min=1.0, version="test")
+        report("Slack 알림", True, "전송 완료")
+except Exception as e:
+    report("Slack 알림", False, str(e))
+
+
+# ────────────────────────────────────────────────────
+# 5) Discord 알림
+# ────────────────────────────────────────────────────
+print("\n[5] Discord 알림")
+try:
+    from automation.notify import Notifier
+    n = Notifier()
+    if not DISCORD_WEBHOOK_URL:
+        report("Discord 알림", True, "스킵 (웹훅 미설정)")
+    else:
+        n.training_complete(TEST_MODEL, dr=74.8, holdout=71.2, fp=1.0,
+                            elapsed_min=1.0, version="test")
+        report("Discord 알림", True, "전송 완료")
+except Exception as e:
+    report("Discord 알림", False, str(e))
+
+
+# ────────────────────────────────────────────────────
+# 6) Google Sheets 기록
+# ────────────────────────────────────────────────────
+print("\n[6] Google Sheets 기록")
+try:
+    from automation.sheets_tracker import SheetsTracker
+    if not GSHEETS_SPREADSHEET_ID:
+        report("Google Sheets", True, "스킵 (SPREADSHEET_ID 미설정)")
+    else:
+        s = SheetsTracker()
+        s.log_result(TEST_MODEL, TEST_EPOCHS, 74.8, 71.2, 1.0, run_id)
+        report("Google Sheets", True, "기록 완료")
+except Exception as e:
+    report("Google Sheets", False, str(e))
+
+
+# ────────────────────────────────────────────────────
+# 7) Notion 페이지 생성
+# ────────────────────────────────────────────────────
+print("\n[7] Notion 페이지 생성")
+try:
+    from automation.notion_reporter import NotionReporter
+    if not NOTION_API_KEY:
+        report("Notion", True, "스킵 (API 키 미설정)")
+    else:
+        r = NotionReporter()
+        page_id = r.create_experiment_page(
+            TEST_MODEL, TEST_EPOCHS, 74.8, 71.2, 1.0,
+            notes="[테스트 런] 시범 가동 — 실제 학습 없음"
+        )
+        report("Notion", True, f"page_id={page_id}")
+except Exception as e:
+    report("Notion", False, str(e))
+
+
+# ────────────────────────────────────────────────────
+# 8) GitHub Release (dry-run)
+# ────────────────────────────────────────────────────
+print("\n[8] GitHub Release 연결 확인")
+try:
+    from automation.github_release import GithubReleaser
+    if not GITHUB_TOKEN:
+        report("GitHub Release", True, "스킵 (토큰 미설정)")
+    else:
+        r = GithubReleaser()
+        latest = r.get_latest_release_tag()
+        report("GitHub Release", True, f"최신 릴리즈: {latest}")
+except Exception as e:
+    report("GitHub Release", False, str(e))
+
+
+# ────────────────────────────────────────────────────
+# 정리
+# ────────────────────────────────────────────────────
+shutil.rmtree(DUMMY_OUTPUT_DIR, ignore_errors=True)
+
+print("\n" + "="*55)
+print("  시범 가동 결과")
+print("="*55)
+ok_cnt   = sum(1 for _, ok, _ in results if ok)
+fail_cnt = sum(1 for _, ok, n in results if not ok and "스킵" not in str(n))
+skip_cnt = sum(1 for _, _, n in results if "스킵" in str(n))
+for name, ok, note in results:
+    icon = PASS if ok else (SKIP if "스킵" in str(note) else FAIL)
+    print(f"  {icon}  {name:<30} {note}")
+
+print(f"\n  통과: {ok_cnt}  |  스킵(미설정): {skip_cnt}  |  실패: {fail_cnt}")
+print("="*55)
+print("\n💡 스킵된 서비스는 automation/.env 에 토큰을 입력하면 활성화됩니다.")

--- a/automation/config.py
+++ b/automation/config.py
@@ -1,0 +1,41 @@
+"""
+automation/config.py
+환경변수 기반 설정 — .env.example 참고
+"""
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+# ─── MLflow ───────────────────────────────────────────────────────────────────
+MLFLOW_TRACKING_URI   = os.getenv("MLFLOW_TRACKING_URI", "http://localhost:5000")
+MLFLOW_EXPERIMENT     = os.getenv("MLFLOW_EXPERIMENT", "ais-anomaly-detection")
+
+# ─── Slack ────────────────────────────────────────────────────────────────────
+SLACK_BOT_TOKEN       = os.getenv("SLACK_BOT_TOKEN", "")
+SLACK_CHANNEL         = os.getenv("SLACK_CHANNEL", "#ais-training-alerts")
+
+# ─── Discord ─────────────────────────────────────────────────────────────────
+DISCORD_WEBHOOK_URL   = os.getenv("DISCORD_WEBHOOK_URL", "")
+
+# ─── Notion ───────────────────────────────────────────────────────────────────
+NOTION_API_KEY        = os.getenv("NOTION_API_KEY", "")
+NOTION_DATABASE_ID    = os.getenv("NOTION_DATABASE_ID", "")
+
+# ─── Google Sheets ────────────────────────────────────────────────────────────
+GSHEETS_CREDS_FILE    = os.getenv("GSHEETS_CREDS_FILE", "automation/credentials.json")
+GSHEETS_SPREADSHEET_ID = os.getenv("GSHEETS_SPREADSHEET_ID", "")
+GSHEETS_SHEET_NAME    = os.getenv("GSHEETS_SHEET_NAME", "pipeline_results")
+
+# ─── GitHub ───────────────────────────────────────────────────────────────────
+GITHUB_TOKEN          = os.getenv("GITHUB_TOKEN", "")
+GITHUB_REPO           = os.getenv("GITHUB_REPO", "heahgo/JB-Pirate-King")
+
+# ─── Pipeline ─────────────────────────────────────────────────────────────────
+BASE_DIR   = os.getenv("BASE_DIR", "D:\\")
+DATA_FILE  = os.getenv(
+    "DATA_FILE",
+    "D:\\ais_data\\preprocessed\\2025\\ais_preprocessed_2025.csv"
+)
+MODELS_DIR = os.getenv("MODELS_DIR", "D:\\ais_models")
+OUTPUT_DIR = os.getenv("OUTPUT_DIR", "D:\\ais_output\\pipeline")

--- a/automation/config.py
+++ b/automation/config.py
@@ -23,9 +23,9 @@ NOTION_API_KEY        = os.getenv("NOTION_API_KEY", "")
 NOTION_DATABASE_ID    = os.getenv("NOTION_DATABASE_ID", "")
 
 # ─── Google Sheets ────────────────────────────────────────────────────────────
-GSHEETS_CREDS_FILE    = os.getenv("GSHEETS_CREDS_FILE", "automation/credentials.json")
+GSHEETS_CREDS_FILE     = os.getenv("GSHEETS_CREDS_FILE", "automation/credentials.json")
 GSHEETS_SPREADSHEET_ID = os.getenv("GSHEETS_SPREADSHEET_ID", "")
-GSHEETS_SHEET_NAME    = os.getenv("GSHEETS_SHEET_NAME", "pipeline_results")
+# 시트명은 sheets_tracker.py에서 상수로 관리 (🤖 ML 모델 성능 / 🔄 실행 로그)
 
 # ─── GitHub ───────────────────────────────────────────────────────────────────
 GITHUB_TOKEN          = os.getenv("GITHUB_TOKEN", "")

--- a/automation/config.py
+++ b/automation/config.py
@@ -8,7 +8,7 @@ from dotenv import load_dotenv
 load_dotenv()
 
 # ─── MLflow ───────────────────────────────────────────────────────────────────
-MLFLOW_TRACKING_URI   = os.getenv("MLFLOW_TRACKING_URI", "http://localhost:5000")
+MLFLOW_TRACKING_URI   = os.getenv("MLFLOW_TRACKING_URI", "sqlite:///mlflow.db")
 MLFLOW_EXPERIMENT     = os.getenv("MLFLOW_EXPERIMENT", "ais-anomaly-detection")
 
 # ─── Slack ────────────────────────────────────────────────────────────────────

--- a/automation/github_release.py
+++ b/automation/github_release.py
@@ -1,0 +1,129 @@
+"""
+automation/github_release.py
+
+GitHub Release를 자동 생성하고 모델 파일을 첨부한다.
+
+사용법:
+    from automation.github_release import GithubReleaser
+
+    r = GithubReleaser()
+    url = r.create_release(
+        tag="v0.2.0",
+        title="v0.2.0 — conv1d / tranad / dcdetect",
+        models=["conv1d", "tranad"],
+        comparison_txt=r"D:\ais_output\pipeline\comparison_20251014.txt",
+        comparison_csv=r"D:\ais_output\pipeline\comparison_20251014.csv",
+        notes={
+            "conv1d":   {"train_dr": 68.3, "holdout_dr": 70.8},
+            "tranad":   {"train_dr": 35.4, "holdout_dr": 61.0},
+        },
+        target_branch="main",
+    )
+"""
+
+import os
+from github import Github, GithubException
+from automation.config import GITHUB_TOKEN, GITHUB_REPO, MODELS_DIR
+
+
+def _model_files(model: str, base_dir: str) -> list[str]:
+    model_dir = os.path.join(base_dir, model)
+    candidates = [
+        os.path.join(model_dir, f"model_{model}.onnx"),
+        os.path.join(model_dir, f"scaler_{model}.json"),
+        os.path.join(model_dir, f"threshold_{model}.txt"),
+        # 루트 레벨 fallback
+        os.path.join(base_dir, f"model_{model}.onnx"),
+        os.path.join(base_dir, f"scaler_{model}.json"),
+        os.path.join(base_dir, f"threshold_{model}.txt"),
+    ]
+    return [p for p in candidates if os.path.exists(p)]
+
+
+def _build_release_notes(models: list[str], notes: dict) -> str:
+    lines = ["## Models", ""]
+    for m in models:
+        lines.append(f"- `{m}`")
+    lines += ["", "## Performance (FP ≈ 1%)", ""]
+    for m in models:
+        if m in notes:
+            d = notes[m]
+            lines.append(
+                f"- **{m}**: 학습 {d.get('train_dr', '?')}% / 홀드아웃 {d.get('holdout_dr', '?')}%"
+            )
+    lines += [
+        "",
+        "## Plugin Deploy",
+        "```",
+        "# 학습 후 플러그인에 모델 배포",
+        "cp model_{name}.onnx ais_ids_pi/data/model.onnx",
+        "cp scaler_{name}.json ais_ids_pi/data/scaler.json",
+        "cp threshold_{name}.txt ais_ids_pi/data/threshold.txt",
+        "```",
+    ]
+    return "\n".join(lines)
+
+
+class GithubReleaser:
+    def __init__(self):
+        if not GITHUB_TOKEN:
+            print("[github] GITHUB_TOKEN 미설정 — GitHub 릴리즈 스킵")
+            self._disabled = True
+            return
+        self._disabled = False
+        self._repo = Github(GITHUB_TOKEN).get_repo(GITHUB_REPO)
+
+    def create_release(
+        self,
+        tag: str,
+        title: str,
+        models: list[str],
+        notes: dict | None = None,
+        comparison_txt: str | None = None,
+        comparison_csv: str | None = None,
+        target_branch: str = "main",
+    ) -> str | None:
+        if self._disabled:
+            return None
+
+        body = _build_release_notes(models, notes or {})
+
+        try:
+            release = self._repo.create_git_release(
+                tag=tag,
+                name=title,
+                message=body,
+                target_commitish=target_branch,
+                draft=False,
+                prerelease=False,
+            )
+        except GithubException as e:
+            print(f"[github] 릴리즈 생성 실패: {e}")
+            return None
+
+        # 모델 파일 첨부
+        for model in models:
+            for path in _model_files(model, MODELS_DIR):
+                fname = os.path.basename(path)
+                with open(path, "rb") as f:
+                    release.upload_asset(path=path, name=fname)
+                print(f"[github] 첨부: {fname}")
+
+        # 비교 리포트 첨부
+        for path in filter(None, [comparison_txt, comparison_csv]):
+            if os.path.exists(path):
+                fname = os.path.basename(path)
+                with open(path, "rb") as f:
+                    release.upload_asset(path=path, name=fname)
+                print(f"[github] 첨부: {fname}")
+
+        print(f"[github] 릴리즈 생성 완료: {release.html_url}")
+        return release.html_url
+
+    def get_latest_release_tag(self) -> str | None:
+        if self._disabled:
+            return None
+        try:
+            return self._repo.get_latest_release().tag_name
+        except GithubException:
+            return None

--- a/automation/mlflow_tracker.py
+++ b/automation/mlflow_tracker.py
@@ -1,0 +1,139 @@
+"""
+automation/mlflow_tracker.py
+
+ml/pipeline.py 실행 결과를 MLflow Experiment에 기록하는 래퍼.
+
+사용법:
+    from automation.mlflow_tracker import MLflowTracker
+
+    tracker = MLflowTracker()
+    with tracker.start_run(model_name="conv1d", epochs=10):
+        # 학습 진행 ...
+        tracker.log_train_params(epochs=10, seq_len=10, n_features=12)
+        tracker.log_epoch_metrics(epoch=5, train_loss=0.02, val_loss=0.03)
+        tracker.log_eval_results(detection_rate=68.3, fp_rate=1.0,
+                                 holdout_dr=70.8, holdout_fp=1.1)
+        tracker.log_model_artifacts(
+            onnx_path=r"D:\ais_models\conv1d\model_conv1d.onnx",
+            scaler_path=r"D:\ais_models\conv1d\scaler_conv1d.json",
+            threshold_path=r"D:\ais_models\conv1d\threshold_conv1d.txt",
+        )
+"""
+
+import os
+import mlflow
+import mlflow.artifacts
+from contextlib import contextmanager
+from automation.config import MLFLOW_TRACKING_URI, MLFLOW_EXPERIMENT
+
+
+class MLflowTracker:
+    def __init__(self):
+        mlflow.set_tracking_uri(MLFLOW_TRACKING_URI)
+        mlflow.set_experiment(MLFLOW_EXPERIMENT)
+        self._run = None
+
+    @contextmanager
+    def start_run(self, model_name: str, epochs: int, run_name: str | None = None):
+        run_name = run_name or f"{model_name}_ep{epochs}"
+        with mlflow.start_run(run_name=run_name) as run:
+            self._run = run
+            mlflow.set_tag("model_name", model_name)
+            yield self
+        self._run = None
+
+    def log_train_params(self, **kwargs):
+        mlflow.log_params(kwargs)
+
+    def log_epoch_metrics(self, epoch: int, **metrics):
+        mlflow.log_metrics(metrics, step=epoch)
+
+    def log_eval_results(
+        self,
+        detection_rate: float,
+        fp_rate: float,
+        holdout_dr: float | None = None,
+        holdout_fp: float | None = None,
+    ):
+        metrics = {
+            "detection_rate": detection_rate,
+            "false_positive_rate": fp_rate,
+        }
+        if holdout_dr is not None:
+            metrics["holdout_detection_rate"] = holdout_dr
+        if holdout_fp is not None:
+            metrics["holdout_fp_rate"] = holdout_fp
+        mlflow.log_metrics(metrics)
+
+    def log_model_artifacts(
+        self,
+        onnx_path: str | None = None,
+        scaler_path: str | None = None,
+        threshold_path: str | None = None,
+    ):
+        for path in (onnx_path, scaler_path, threshold_path):
+            if path and os.path.exists(path):
+                mlflow.log_artifact(path)
+
+    def log_comparison_csv(self, csv_path: str):
+        if os.path.exists(csv_path):
+            mlflow.log_artifact(csv_path, artifact_path="reports")
+
+    def get_run_id(self) -> str | None:
+        return self._run.info.run_id if self._run else None
+
+
+def patch_pipeline_with_mlflow(model_name: str, epochs: int):
+    """
+    pipeline.py를 직접 수정하지 않고 실행 후 결과를 MLflow에 기록하는 헬퍼.
+    pipeline_runner.py에서 호출됨.
+    """
+    import glob
+    import csv
+    from automation.config import OUTPUT_DIR
+
+    tracker = MLflowTracker()
+
+    pattern = os.path.join(OUTPUT_DIR, f"{model_name}_*.csv")
+    files = sorted(glob.glob(pattern))
+    if not files:
+        print(f"[mlflow] {model_name} 결과 CSV를 찾을 수 없음: {pattern}")
+        return
+
+    latest_csv = files[-1]
+    with open(latest_csv, newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+
+    if not rows:
+        return
+
+    with tracker.start_run(model_name=model_name, epochs=epochs):
+        tracker.log_train_params(
+            model=model_name,
+            epochs=epochs,
+            seq_len=10,
+            n_features=12,
+        )
+
+        train_drs, holdout_drs = [], []
+        for row in rows:
+            group = row.get("group", "")
+            dr = float(row.get("detection_rate", 0))
+            if group.startswith("F") or group.startswith("G"):
+                holdout_drs.append(dr)
+            else:
+                train_drs.append(dr)
+
+        avg_train   = sum(train_drs)   / len(train_drs)   if train_drs   else 0
+        avg_holdout = sum(holdout_drs) / len(holdout_drs) if holdout_drs else 0
+
+        tracker.log_eval_results(
+            detection_rate=avg_train,
+            fp_rate=1.0,
+            holdout_dr=avg_holdout,
+            holdout_fp=1.0,
+        )
+        tracker.log_comparison_csv(latest_csv)
+
+    print(f"[mlflow] {model_name} 실험 기록 완료 (train DR={avg_train:.1f}%, holdout DR={avg_holdout:.1f}%)")

--- a/automation/notify.py
+++ b/automation/notify.py
@@ -1,0 +1,165 @@
+"""
+automation/notify.py
+
+Slack + Discord 알림 유틸리티.
+성공/실패/결과 요약 메시지를 각 채널에 전송한다.
+
+사용법:
+    from automation.notify import Notifier
+    n = Notifier()
+    n.training_complete("conv1d", dr=68.3, holdout=70.8, fp=1.0, elapsed_min=42)
+    n.pipeline_failed("conv1d", "OOM at epoch 5")
+"""
+
+import json
+import requests
+from datetime import datetime
+from automation.config import (
+    SLACK_BOT_TOKEN,
+    SLACK_CHANNEL,
+    DISCORD_WEBHOOK_URL,
+)
+
+
+# ─── Slack ────────────────────────────────────────────────────────────────────
+
+def _slack_post(text: str, blocks: list | None = None) -> bool:
+    if not SLACK_BOT_TOKEN:
+        print("[notify] SLACK_BOT_TOKEN 미설정 — Slack 알림 스킵")
+        return False
+
+    payload: dict = {"channel": SLACK_CHANNEL, "text": text}
+    if blocks:
+        payload["blocks"] = blocks
+
+    resp = requests.post(
+        "https://slack.com/api/chat.postMessage",
+        headers={"Authorization": f"Bearer {SLACK_BOT_TOKEN}",
+                 "Content-Type": "application/json"},
+        data=json.dumps(payload),
+        timeout=10,
+    )
+    ok = resp.json().get("ok", False)
+    if not ok:
+        print(f"[notify] Slack 오류: {resp.json().get('error')}")
+    return ok
+
+
+# ─── Discord ─────────────────────────────────────────────────────────────────
+
+def _discord_post(content: str, embeds: list | None = None) -> bool:
+    if not DISCORD_WEBHOOK_URL:
+        print("[notify] DISCORD_WEBHOOK_URL 미설정 — Discord 알림 스킵")
+        return False
+
+    payload: dict = {"content": content}
+    if embeds:
+        payload["embeds"] = embeds
+
+    resp = requests.post(
+        DISCORD_WEBHOOK_URL,
+        json=payload,
+        timeout=10,
+    )
+    if resp.status_code not in (200, 204):
+        print(f"[notify] Discord 오류: {resp.status_code} {resp.text}")
+        return False
+    return True
+
+
+# ─── Public API ───────────────────────────────────────────────────────────────
+
+class Notifier:
+    def training_complete(
+        self,
+        model: str,
+        dr: float,
+        holdout: float,
+        fp: float,
+        elapsed_min: float,
+        version: str = "",
+    ):
+        ts = datetime.now().strftime("%Y-%m-%d %H:%M")
+        label = f"v{version} " if version else ""
+
+        # Slack blocks
+        blocks = [
+            {"type": "header",
+             "text": {"type": "plain_text",
+                      "text": f"✅ [{model}] 학습 완료 {label}"}},
+            {"type": "section",
+             "fields": [
+                 {"type": "mrkdwn", "text": f"*탐지율 (학습)*\n{dr:.1f}%"},
+                 {"type": "mrkdwn", "text": f"*탐지율 (홀드아웃)*\n{holdout:.1f}%"},
+                 {"type": "mrkdwn", "text": f"*오탐율*\n{fp:.1f}%"},
+                 {"type": "mrkdwn", "text": f"*소요 시간*\n{elapsed_min:.0f}분"},
+             ]},
+            {"type": "context",
+             "elements": [{"type": "mrkdwn", "text": f"완료 시각: {ts}"}]},
+        ]
+        _slack_post(f"[AIS] {model} 학습 완료 — DR {dr:.1f}% / Holdout {holdout:.1f}%", blocks)
+
+        # Discord embed
+        embeds = [{
+            "title": f"✅ [{model}] 학습 완료 {label}",
+            "color": 0x2ECC71,
+            "fields": [
+                {"name": "탐지율 (학습)", "value": f"{dr:.1f}%", "inline": True},
+                {"name": "탐지율 (홀드아웃)", "value": f"{holdout:.1f}%", "inline": True},
+                {"name": "오탐율", "value": f"{fp:.1f}%", "inline": True},
+                {"name": "소요 시간", "value": f"{elapsed_min:.0f}분", "inline": True},
+            ],
+            "footer": {"text": ts},
+        }]
+        _discord_post(f"AIS 학습 완료: **{model}**", embeds)
+
+    def pipeline_failed(self, model: str, reason: str):
+        ts = datetime.now().strftime("%Y-%m-%d %H:%M")
+
+        _slack_post(
+            f"❌ [{model}] 파이프라인 실패",
+            blocks=[
+                {"type": "header",
+                 "text": {"type": "plain_text", "text": f"❌ [{model}] 파이프라인 실패"}},
+                {"type": "section",
+                 "text": {"type": "mrkdwn", "text": f"*오류 내용*\n```{reason}```"}},
+                {"type": "context",
+                 "elements": [{"type": "mrkdwn", "text": ts}]},
+            ],
+        )
+        _discord_post(
+            f"AIS 파이프라인 실패: **{model}**",
+            embeds=[{
+                "title": f"❌ [{model}] 파이프라인 실패",
+                "color": 0xE74C3C,
+                "description": f"```{reason[:1000]}```",
+                "footer": {"text": ts},
+            }],
+        )
+
+    def release_created(self, tag: str, url: str, models: list[str]):
+        ts = datetime.now().strftime("%Y-%m-%d %H:%M")
+        model_list = ", ".join(models)
+
+        _slack_post(
+            f"🚀 릴리즈 {tag} 생성됨",
+            blocks=[
+                {"type": "header",
+                 "text": {"type": "plain_text", "text": f"🚀 GitHub 릴리즈 {tag}"}},
+                {"type": "section",
+                 "fields": [
+                     {"type": "mrkdwn", "text": f"*모델*\n{model_list}"},
+                     {"type": "mrkdwn", "text": f"*URL*\n<{url}|릴리즈 보기>"},
+                 ]},
+                {"type": "context",
+                 "elements": [{"type": "mrkdwn", "text": ts}]},
+            ],
+        )
+        _discord_post(
+            f"🚀 AIS 릴리즈 **{tag}** 생성됨 — {model_list}\n{url}",
+        )
+
+    def data_updated(self, file_count: int, coverage: str):
+        msg = f"📦 AIS 데이터 업데이트: {file_count}개 파일, 커버리지 {coverage}"
+        _slack_post(msg)
+        _discord_post(msg)

--- a/automation/notify.py
+++ b/automation/notify.py
@@ -20,6 +20,10 @@ from automation.config import (
     DISCORD_WEBHOOK_URL,
 )
 
+# Discord Docker MCP 로컬 엔드포인트 (port 8085)
+# 웹훅 URL이 없을 때 fallback으로 사용
+DISCORD_LOCAL_MCP_URL = "http://localhost:8085/send"
+
 
 # ─── Slack ────────────────────────────────────────────────────────────────────
 
@@ -46,25 +50,34 @@ def _slack_post(text: str, blocks: list | None = None) -> bool:
 
 
 # ─── Discord ─────────────────────────────────────────────────────────────────
+# 우선순위: 1) 표준 웹훅 URL  2) Docker MCP (localhost:8085)
 
 def _discord_post(content: str, embeds: list | None = None) -> bool:
-    if not DISCORD_WEBHOOK_URL:
-        print("[notify] DISCORD_WEBHOOK_URL 미설정 — Discord 알림 스킵")
-        return False
-
     payload: dict = {"content": content}
     if embeds:
         payload["embeds"] = embeds
 
-    resp = requests.post(
-        DISCORD_WEBHOOK_URL,
-        json=payload,
-        timeout=10,
-    )
-    if resp.status_code not in (200, 204):
-        print(f"[notify] Discord 오류: {resp.status_code} {resp.text}")
+    # 1) 표준 Discord 웹훅
+    if DISCORD_WEBHOOK_URL:
+        resp = requests.post(DISCORD_WEBHOOK_URL, json=payload, timeout=10)
+        if resp.status_code in (200, 204):
+            return True
+        print(f"[notify] Discord 웹훅 오류: {resp.status_code} — Docker MCP 시도")
+
+    # 2) Docker MCP fallback (localhost:8085)
+    try:
+        resp = requests.post(
+            DISCORD_LOCAL_MCP_URL,
+            json={"message": content},
+            timeout=5,
+        )
+        if resp.status_code in (200, 204):
+            return True
+        print(f"[notify] Discord Docker MCP 오류: {resp.status_code} {resp.text}")
         return False
-    return True
+    except requests.ConnectionError:
+        print("[notify] Discord 웹훅/Docker MCP 모두 미설정 또는 미실행 — 스킵")
+        return False
 
 
 # ─── Public API ───────────────────────────────────────────────────────────────

--- a/automation/notion_reporter.py
+++ b/automation/notion_reporter.py
@@ -1,0 +1,114 @@
+"""
+automation/notion_reporter.py
+
+학습 완료 시 Notion Database에 실험 결과 페이지를 자동 생성한다.
+
+Notion Database 필수 속성:
+  - Name (title)        : 모델명 + 타임스탬프
+  - Model (select)      : conv1d / tranad / dcdetect ...
+  - Status (select)     : Training / Evaluating / Done / Failed
+  - Train DR (number)   : 탐지율 (학습)
+  - Holdout DR (number) : 탐지율 (홀드아웃)
+  - FP Rate (number)    : 오탐율
+  - Epochs (number)     : 학습 에포크 수
+  - Date (date)         : 실험 날짜
+  - Release (url)       : GitHub 릴리즈 URL
+
+사용법:
+    from automation.notion_reporter import NotionReporter
+    r = NotionReporter()
+    r.create_experiment_page(
+        model="conv1d", epochs=10,
+        train_dr=68.3, holdout_dr=70.8, fp_rate=1.0,
+        release_url="https://github.com/heahgo/JB-Pirate-King/releases/tag/v0.1.0",
+        notes="3-year balanced dataset, SEQ_LEN=10",
+    )
+"""
+
+from datetime import datetime, timezone
+from notion_client import Client
+from automation.config import NOTION_API_KEY, NOTION_DATABASE_ID
+
+
+class NotionReporter:
+    def __init__(self):
+        if not NOTION_API_KEY or not NOTION_DATABASE_ID:
+            print("[notion] NOTION_API_KEY 또는 NOTION_DATABASE_ID 미설정 — Notion 스킵")
+            self._disabled = True
+            return
+        self._disabled = False
+        self._client = Client(auth=NOTION_API_KEY)
+
+    def create_experiment_page(
+        self,
+        model: str,
+        epochs: int,
+        train_dr: float,
+        holdout_dr: float,
+        fp_rate: float,
+        release_url: str = "",
+        notes: str = "",
+        status: str = "Done",
+    ) -> str | None:
+        if self._disabled:
+            return None
+
+        ts = datetime.now(timezone.utc).isoformat()
+        title = f"[{model}] ep{epochs} — {datetime.now().strftime('%Y-%m-%d')}"
+
+        properties: dict = {
+            "Name":       {"title":  [{"text": {"content": title}}]},
+            "Model":      {"select": {"name": model}},
+            "Status":     {"select": {"name": status}},
+            "Train DR":   {"number": round(train_dr, 2)},
+            "Holdout DR": {"number": round(holdout_dr, 2)},
+            "FP Rate":    {"number": round(fp_rate, 2)},
+            "Epochs":     {"number": epochs},
+            "Date":       {"date": {"start": ts}},
+        }
+        if release_url:
+            properties["Release"] = {"url": release_url}
+
+        children = []
+        if notes:
+            children.append({
+                "object": "block",
+                "type": "paragraph",
+                "paragraph": {
+                    "rich_text": [{"type": "text", "text": {"content": notes}}]
+                },
+            })
+
+        result_table = (
+            f"| 항목 | 값 |\n"
+            f"| --- | --- |\n"
+            f"| 모델 | {model} |\n"
+            f"| 에포크 | {epochs} |\n"
+            f"| 탐지율 (학습) | {train_dr:.1f}% |\n"
+            f"| 탐지율 (홀드아웃) | {holdout_dr:.1f}% |\n"
+            f"| 오탐율 | {fp_rate:.1f}% |\n"
+        )
+        children.append({
+            "object": "block",
+            "type": "paragraph",
+            "paragraph": {
+                "rich_text": [{"type": "text", "text": {"content": result_table}}]
+            },
+        })
+
+        resp = self._client.pages.create(
+            parent={"database_id": NOTION_DATABASE_ID},
+            properties=properties,
+            children=children,
+        )
+        page_id = resp["id"]
+        print(f"[notion] 실험 페이지 생성됨: {page_id}")
+        return page_id
+
+    def update_status(self, page_id: str, status: str):
+        if self._disabled:
+            return
+        self._client.pages.update(
+            page_id=page_id,
+            properties={"Status": {"select": {"name": status}}},
+        )

--- a/automation/pipeline_runner.py
+++ b/automation/pipeline_runner.py
@@ -1,0 +1,205 @@
+"""
+automation/pipeline_runner.py
+
+전체 자동화 파이프라인 오케스트레이터.
+ml/pipeline.py 실행 + MLflow + Google Sheets + Notion + GitHub 릴리즈 + Slack/Discord 알림.
+
+사용법:
+    python automation/pipeline_runner.py --models conv1d tranad dcdetect --epochs 10
+    python automation/pipeline_runner.py --models conv1d --epochs 5 --release --tag v0.2.0
+    python automation/pipeline_runner.py --eval-only --models conv1d
+
+옵션:
+    --models      학습할 모델 목록 (기본: conv1d tranad dcdetect)
+    --epochs      에포크 수 (기본: 10)
+    --n_anom      이상 시나리오 수 (기본: 200)
+    --fp_targets  오탐율 목표 (기본: 1)
+    --skip_trained 이미 학습된 모델 스킵
+    --eval-only   평가만 실행
+    --release     학습 완료 후 GitHub 릴리즈 생성
+    --tag         릴리즈 태그 (--release 와 함께)
+    --base_dir    모델/출력 루트 디렉토리 (기본: D:\\)
+"""
+
+import argparse
+import subprocess
+import sys
+import time
+import os
+import glob
+from datetime import datetime
+from pathlib import Path
+
+# automation 패키지 경로 등록
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from automation.config import OUTPUT_DIR, MODELS_DIR, DATA_FILE, BASE_DIR
+from automation.mlflow_tracker import patch_pipeline_with_mlflow
+from automation.notify import Notifier
+from automation.sheets_tracker import SheetsTracker
+from automation.notion_reporter import NotionReporter
+from automation.github_release import GithubReleaser
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description="AIS 이상탐지 자동화 파이프라인")
+    p.add_argument("--models", nargs="+", default=["conv1d", "tranad", "dcdetect"])
+    p.add_argument("--epochs", type=int, default=10)
+    p.add_argument("--n_anom", type=int, default=200)
+    p.add_argument("--fp_targets", type=int, default=1)
+    p.add_argument("--skip_trained", action="store_true")
+    p.add_argument("--eval-only", action="store_true")
+    p.add_argument("--release", action="store_true")
+    p.add_argument("--tag", type=str, default="")
+    p.add_argument("--base_dir", type=str, default=BASE_DIR)
+    return p.parse_args()
+
+
+def run_pipeline(args) -> tuple[bool, str]:
+    """ml/pipeline.py 실행, (성공여부, 오류메시지) 반환"""
+    cmd = [sys.executable, "ml/pipeline.py"]
+
+    if args.eval_only:
+        cmd += ["--eval"]
+    else:
+        cmd += ["--train", "--eval"]
+
+    cmd += ["--models", *args.models]
+    cmd += ["--epochs", str(args.epochs)]
+    cmd += ["--n_anom", str(args.n_anom)]
+    cmd += ["--fp_targets", str(args.fp_targets)]
+    cmd += ["--base_dir", args.base_dir]
+    if args.skip_trained:
+        cmd.append("--skip_trained")
+
+    print(f"[runner] 실행: {' '.join(cmd)}")
+    result = subprocess.run(cmd, capture_output=False, text=True)
+
+    if result.returncode != 0:
+        return False, f"exit code {result.returncode}"
+    return True, ""
+
+
+def parse_eval_results(model: str, base_dir: str) -> dict:
+    """최신 per-model CSV에서 탐지율 요약 추출"""
+    out_dir = os.path.join(base_dir, "ais_output", "pipeline")
+    pattern = os.path.join(out_dir, f"{model}_*.csv")
+    files = sorted(glob.glob(pattern))
+    if not files:
+        return {"train_dr": 0.0, "holdout_dr": 0.0, "fp_rate": 1.0}
+
+    import csv
+    train_drs, holdout_drs = [], []
+    with open(files[-1], newline="", encoding="utf-8") as f:
+        for row in csv.DictReader(f):
+            group = row.get("group", "")
+            dr = float(row.get("detection_rate", 0))
+            if group.startswith("F") or group.startswith("G"):
+                holdout_drs.append(dr)
+            else:
+                train_drs.append(dr)
+
+    return {
+        "train_dr":   sum(train_drs)   / len(train_drs)   if train_drs   else 0.0,
+        "holdout_dr": sum(holdout_drs) / len(holdout_drs) if holdout_drs else 0.0,
+        "fp_rate":    1.0,
+    }
+
+
+def find_latest_comparison(base_dir: str) -> tuple[str, str]:
+    out_dir = os.path.join(base_dir, "ais_output", "pipeline")
+    txts = sorted(glob.glob(os.path.join(out_dir, "comparison_*.txt")))
+    csvs = sorted(glob.glob(os.path.join(out_dir, "comparison_*.csv")))
+    return (txts[-1] if txts else ""), (csvs[-1] if csvs else "")
+
+
+def main():
+    args = parse_args()
+    notifier = Notifier()
+    sheets   = SheetsTracker()
+    notion   = NotionReporter()
+    releaser = GithubReleaser()
+
+    print(f"\n{'='*60}")
+    print(f"AIS 자동화 파이프라인 시작")
+    print(f"모델: {args.models}, 에포크: {args.epochs}, eval-only: {args.eval_only}")
+    print(f"{'='*60}\n")
+
+    start = time.time()
+    success, err = run_pipeline(args)
+    elapsed_min = (time.time() - start) / 60
+
+    if not success:
+        print(f"[runner] ❌ 파이프라인 실패: {err}")
+        notifier.pipeline_failed(str(args.models), err)
+        sys.exit(1)
+
+    print(f"\n[runner] ✅ 파이프라인 완료 ({elapsed_min:.1f}분)\n")
+
+    model_results = {}
+    release_url = ""
+
+    for model in args.models:
+        res = parse_eval_results(model, args.base_dir)
+        model_results[model] = res
+
+        # MLflow 기록
+        patch_pipeline_with_mlflow(model, args.epochs)
+
+        # Google Sheets 기록
+        sheets.log_result(
+            model=model,
+            epochs=args.epochs,
+            train_dr=res["train_dr"],
+            holdout_dr=res["holdout_dr"],
+            fp_rate=res["fp_rate"],
+        )
+
+        # Notion 페이지 생성
+        notion.create_experiment_page(
+            model=model,
+            epochs=args.epochs,
+            train_dr=res["train_dr"],
+            holdout_dr=res["holdout_dr"],
+            fp_rate=res["fp_rate"],
+        )
+
+        # Slack + Discord 알림
+        notifier.training_complete(
+            model=model,
+            dr=res["train_dr"],
+            holdout=res["holdout_dr"],
+            fp=res["fp_rate"],
+            elapsed_min=elapsed_min,
+            version=args.tag.lstrip("v") if args.tag else "",
+        )
+
+    # GitHub 릴리즈 생성 (--release 플래그)
+    if args.release and args.tag:
+        cmp_txt, cmp_csv = find_latest_comparison(args.base_dir)
+        notes = {m: {"train_dr": model_results[m]["train_dr"],
+                     "holdout_dr": model_results[m]["holdout_dr"]}
+                 for m in args.models}
+
+        release_url = releaser.create_release(
+            tag=args.tag,
+            title=f"{args.tag} — {' / '.join(args.models)}",
+            models=args.models,
+            notes=notes,
+            comparison_txt=cmp_txt,
+            comparison_csv=cmp_csv,
+        )
+        if release_url:
+            notifier.release_created(args.tag, release_url, args.models)
+
+    print(f"\n{'='*60}")
+    print(f"파이프라인 완료 요약")
+    for m, r in model_results.items():
+        print(f"  {m}: DR {r['train_dr']:.1f}% / Holdout {r['holdout_dr']:.1f}%")
+    if release_url:
+        print(f"  릴리즈: {release_url}")
+    print(f"{'='*60}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/automation/requirements.txt
+++ b/automation/requirements.txt
@@ -1,0 +1,24 @@
+# automation/ 의존성
+# pip install -r automation/requirements.txt
+
+# MLflow — 실험 추적 및 모델 레지스트리
+mlflow>=2.14.0
+
+# Slack 알림
+slack-sdk>=3.27.0
+
+# Discord는 requests로 처리 (별도 SDK 불필요)
+requests>=2.31.0
+
+# Google Sheets
+gspread>=6.1.0
+google-auth>=2.29.0
+
+# Notion
+notion-client>=2.2.1
+
+# GitHub API
+PyGithub>=2.3.0
+
+# 환경변수 로딩
+python-dotenv>=1.0.1

--- a/automation/sheets_tracker.py
+++ b/automation/sheets_tracker.py
@@ -2,9 +2,10 @@
 automation/sheets_tracker.py
 
 Google Sheets에 학습 결과를 기록한다.
-시트 구조:
-  pipeline_results  — 모델별 실험 결과
-  data_coverage     — 전처리된 날짜 범위 추적
+기존 스프레드시트 시트 구조에 맞춰 정확한 시트명/컬럼을 사용한다.
+
+  🤖 ML 모델 성능  — 모델별 탐지율 결과
+  🔄 실행 로그     — 파이프라인 실행 이력
 
 사용 전 준비:
   1. Google Cloud Console → 서비스 계정 생성 → JSON 키 다운로드
@@ -12,13 +13,13 @@ Google Sheets에 학습 결과를 기록한다.
   3. GSHEETS_CREDS_FILE=automation/credentials.json 설정
 """
 
+import uuid
 from datetime import datetime
 import gspread
 from google.oauth2.service_account import Credentials
 from automation.config import (
     GSHEETS_CREDS_FILE,
     GSHEETS_SPREADSHEET_ID,
-    GSHEETS_SHEET_NAME,
 )
 
 SCOPES = [
@@ -26,27 +27,20 @@ SCOPES = [
     "https://www.googleapis.com/auth/drive",
 ]
 
-_RESULT_HEADERS = [
-    "timestamp", "model", "epochs", "seq_len", "n_features",
-    "train_dr_%", "holdout_dr_%", "fp_rate_%",
-    "mlflow_run_id", "github_release",
-]
+# 기존 시트명 (실제 스프레드시트와 일치)
+SHEET_ML_PERF  = "🤖 ML 모델 성능"
+SHEET_RUN_LOG  = "🔄 실행 로그"
 
-_COVERAGE_HEADERS = [
-    "timestamp", "raw_files", "date_start", "date_end",
-    "preprocessed_rows", "notes",
-]
+# 🤖 ML 모델 성능 컬럼 (기존 헤더 행 보존, append only)
+# 모델 | 유형 | 오탐율 | 학습 시나리오 탐지율 | 홀드아웃 F 탐지율 | 홀드아웃 G 탐지율 | 특이사항 | 배포여부
+
+# 🔄 실행 로그 컬럼 (기존 헤더와 동일)
+# 실행ID | 시작시간 | 종료시간 | 모델 | 단계 | 상태 | 소요시간(초) | 비고
 
 
 def _get_client():
     creds = Credentials.from_service_account_file(GSHEETS_CREDS_FILE, scopes=SCOPES)
     return gspread.authorize(creds)
-
-
-def _ensure_headers(ws, headers: list[str]):
-    existing = ws.row_values(1)
-    if existing != headers:
-        ws.insert_row(headers, 1)
 
 
 class SheetsTracker:
@@ -55,22 +49,80 @@ class SheetsTracker:
             print("[sheets] GSHEETS_SPREADSHEET_ID 미설정 — Google Sheets 스킵")
             self._disabled = True
             return
-        self._disabled = False
 
-        client = _get_client()
-        self._ss = client.open_by_key(GSHEETS_SPREADSHEET_ID)
-
-        self._results_ws  = self._get_or_create_sheet(GSHEETS_SHEET_NAME, _RESULT_HEADERS)
-        self._coverage_ws = self._get_or_create_sheet("data_coverage", _COVERAGE_HEADERS)
-
-    def _get_or_create_sheet(self, name: str, headers: list[str]):
         try:
-            ws = self._ss.worksheet(name)
-        except gspread.WorksheetNotFound:
-            ws = self._ss.add_worksheet(title=name, rows=1000, cols=len(headers))
-        _ensure_headers(ws, headers)
-        return ws
+            client = _get_client()
+            self._ss = client.open_by_key(GSHEETS_SPREADSHEET_ID)
+            self._perf_ws = self._ss.worksheet(SHEET_ML_PERF)
+            self._log_ws  = self._ss.worksheet(SHEET_RUN_LOG)
+            self._disabled = False
+        except Exception as e:
+            print(f"[sheets] 연결 실패: {e}")
+            self._disabled = True
 
+    # ── ML 모델 성능 시트 ─────────────────────────────────────────────
+    def log_model_result(
+        self,
+        model: str,
+        model_type: str,            # "비지도학습" | "지도학습"
+        fp_rate: float,             # 오탐율 (%)
+        train_dr: float,            # 학습 시나리오 탐지율 (%)
+        holdout_f_dr: float | None = None,  # 홀드아웃 F 탐지율
+        holdout_g_dr: float | None = None,  # 홀드아웃 G 탐지율
+        notes: str = "",
+        deployed: bool = False,
+    ):
+        if self._disabled:
+            return
+        row = [
+            model,
+            model_type,
+            f"{fp_rate:.2f}%",
+            f"{train_dr:.2f}%",
+            f"{holdout_f_dr:.2f}%" if holdout_f_dr is not None else "-",
+            f"{holdout_g_dr:.2f}%" if holdout_g_dr is not None else "-",
+            notes,
+            "✅ 배포" if deployed else "",
+        ]
+        self._perf_ws.append_row(row)
+        print(f"[sheets] 🤖 ML 모델 성능 기록: {model}")
+
+    # ── 실행 로그 시트 ────────────────────────────────────────────────
+    def log_run_start(
+        self, model: str, step: str, run_id: str | None = None
+    ) -> tuple[str, str]:
+        """실행 시작 기록. (run_id, start_time) 반환"""
+        if self._disabled:
+            return "", ""
+        run_id = run_id or f"auto_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+        start = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        self._log_ws.append_row([
+            run_id, start, "", model, step, "실행중", "", "",
+        ])
+        print(f"[sheets] 🔄 실행 시작: {run_id} / {model} / {step}")
+        return run_id, start
+
+    def log_run_end(
+        self,
+        run_id: str,
+        start_time: str,
+        model: str,
+        step: str,
+        status: str,          # "완료" | "실패"
+        elapsed_sec: float,
+        notes: str = "",
+    ):
+        """실행 완료 기록 (새 행 append)"""
+        if self._disabled:
+            return
+        end = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        self._log_ws.append_row([
+            run_id, start_time, end, model, step, status,
+            round(elapsed_sec, 1), notes,
+        ])
+        print(f"[sheets] 🔄 실행 완료: {run_id} → {status} ({elapsed_sec:.0f}s)")
+
+    # ── 편의 래퍼 (pipeline_runner.py 호환) ─────────────────────────
     def log_result(
         self,
         model: str,
@@ -80,41 +132,41 @@ class SheetsTracker:
         fp_rate: float,
         mlflow_run_id: str = "",
         github_release: str = "",
+        holdout_g_dr: float | None = None,
     ):
-        if self._disabled:
-            return
-        self._results_ws.append_row([
-            datetime.now().strftime("%Y-%m-%d %H:%M"),
-            model, epochs, 10, 12,
-            round(train_dr, 2),
-            round(holdout_dr, 2),
-            round(fp_rate, 2),
-            mlflow_run_id,
-            github_release,
-        ])
-        print(f"[sheets] {model} 결과 기록 완료")
+        """pipeline_runner.py에서 호출하는 통합 결과 기록"""
+        notes_parts = []
+        if mlflow_run_id:
+            notes_parts.append(f"mlflow:{mlflow_run_id[:8]}")
+        if github_release:
+            notes_parts.append(github_release)
+        if epochs:
+            notes_parts.append(f"ep{epochs}")
 
-    def log_data_coverage(
-        self,
-        raw_files: int,
-        date_start: str,
-        date_end: str,
-        preprocessed_rows: int,
-        notes: str = "",
-    ):
-        if self._disabled:
-            return
-        self._coverage_ws.append_row([
-            datetime.now().strftime("%Y-%m-%d %H:%M"),
-            raw_files, date_start, date_end,
-            preprocessed_rows, notes,
-        ])
-        print(f"[sheets] 데이터 커버리지 기록 완료 ({date_start} ~ {date_end})")
+        self.log_model_result(
+            model=model,
+            model_type="비지도학습",
+            fp_rate=fp_rate,
+            train_dr=train_dr,
+            holdout_f_dr=holdout_dr,
+            holdout_g_dr=holdout_g_dr,
+            notes=", ".join(notes_parts),
+        )
 
     def get_best_model(self) -> dict | None:
+        """홀드아웃 F 탐지율 기준 최고 모델 반환"""
         if self._disabled:
             return None
-        rows = self._results_ws.get_all_records()
-        if not rows:
+        try:
+            rows = self._perf_ws.get_all_records()
+            if not rows:
+                return None
+            def _dr(r):
+                v = str(r.get("홀드아웃 F 탐지율", "0")).replace("%", "").strip()
+                try:
+                    return float(v)
+                except ValueError:
+                    return 0.0
+            return max(rows, key=_dr)
+        except Exception:
             return None
-        return max(rows, key=lambda r: float(r.get("holdout_dr_%", 0)))

--- a/automation/sheets_tracker.py
+++ b/automation/sheets_tracker.py
@@ -1,0 +1,120 @@
+"""
+automation/sheets_tracker.py
+
+Google Sheets에 학습 결과를 기록한다.
+시트 구조:
+  pipeline_results  — 모델별 실험 결과
+  data_coverage     — 전처리된 날짜 범위 추적
+
+사용 전 준비:
+  1. Google Cloud Console → 서비스 계정 생성 → JSON 키 다운로드
+  2. 해당 서비스 계정 이메일을 시트에 편집자로 공유
+  3. GSHEETS_CREDS_FILE=automation/credentials.json 설정
+"""
+
+from datetime import datetime
+import gspread
+from google.oauth2.service_account import Credentials
+from automation.config import (
+    GSHEETS_CREDS_FILE,
+    GSHEETS_SPREADSHEET_ID,
+    GSHEETS_SHEET_NAME,
+)
+
+SCOPES = [
+    "https://www.googleapis.com/auth/spreadsheets",
+    "https://www.googleapis.com/auth/drive",
+]
+
+_RESULT_HEADERS = [
+    "timestamp", "model", "epochs", "seq_len", "n_features",
+    "train_dr_%", "holdout_dr_%", "fp_rate_%",
+    "mlflow_run_id", "github_release",
+]
+
+_COVERAGE_HEADERS = [
+    "timestamp", "raw_files", "date_start", "date_end",
+    "preprocessed_rows", "notes",
+]
+
+
+def _get_client():
+    creds = Credentials.from_service_account_file(GSHEETS_CREDS_FILE, scopes=SCOPES)
+    return gspread.authorize(creds)
+
+
+def _ensure_headers(ws, headers: list[str]):
+    existing = ws.row_values(1)
+    if existing != headers:
+        ws.insert_row(headers, 1)
+
+
+class SheetsTracker:
+    def __init__(self):
+        if not GSHEETS_SPREADSHEET_ID:
+            print("[sheets] GSHEETS_SPREADSHEET_ID 미설정 — Google Sheets 스킵")
+            self._disabled = True
+            return
+        self._disabled = False
+
+        client = _get_client()
+        self._ss = client.open_by_key(GSHEETS_SPREADSHEET_ID)
+
+        self._results_ws  = self._get_or_create_sheet(GSHEETS_SHEET_NAME, _RESULT_HEADERS)
+        self._coverage_ws = self._get_or_create_sheet("data_coverage", _COVERAGE_HEADERS)
+
+    def _get_or_create_sheet(self, name: str, headers: list[str]):
+        try:
+            ws = self._ss.worksheet(name)
+        except gspread.WorksheetNotFound:
+            ws = self._ss.add_worksheet(title=name, rows=1000, cols=len(headers))
+        _ensure_headers(ws, headers)
+        return ws
+
+    def log_result(
+        self,
+        model: str,
+        epochs: int,
+        train_dr: float,
+        holdout_dr: float,
+        fp_rate: float,
+        mlflow_run_id: str = "",
+        github_release: str = "",
+    ):
+        if self._disabled:
+            return
+        self._results_ws.append_row([
+            datetime.now().strftime("%Y-%m-%d %H:%M"),
+            model, epochs, 10, 12,
+            round(train_dr, 2),
+            round(holdout_dr, 2),
+            round(fp_rate, 2),
+            mlflow_run_id,
+            github_release,
+        ])
+        print(f"[sheets] {model} 결과 기록 완료")
+
+    def log_data_coverage(
+        self,
+        raw_files: int,
+        date_start: str,
+        date_end: str,
+        preprocessed_rows: int,
+        notes: str = "",
+    ):
+        if self._disabled:
+            return
+        self._coverage_ws.append_row([
+            datetime.now().strftime("%Y-%m-%d %H:%M"),
+            raw_files, date_start, date_end,
+            preprocessed_rows, notes,
+        ])
+        print(f"[sheets] 데이터 커버리지 기록 완료 ({date_start} ~ {date_end})")
+
+    def get_best_model(self) -> dict | None:
+        if self._disabled:
+            return None
+        rows = self._results_ws.get_all_records()
+        if not rows:
+            return None
+        return max(rows, key=lambda r: float(r.get("holdout_dr_%", 0)))


### PR DESCRIPTION
## Summary

- `automation/` 디렉토리 신설 — ML 파이프라인 전체 자동화 레이어
- MLflow 실험 추적, Google Sheets 결과 기록, Notion 문서화, Slack/Discord 알림, GitHub 릴리즈 자동화 통합
- GitHub Actions 워크플로 2개 추가 (daily 학습 + 태그 기반 릴리즈)

## 아키텍처 다이어그램

[FigJam — JB-Pirate-King AIS 이상탐지 자동화 파이프라인](https://www.figma.com/board/cyTCcQ6zhHlVIrcjSBufli)

## 추가된 파일

| 파일 | 역할 |
|------|------|
| `automation/pipeline_runner.py` | 메인 진입점 — `ml/pipeline.py` 래핑 후 모든 서비스 연동 |
| `automation/mlflow_tracker.py` | MLflow 실험/런 기록 (params, metrics, ONNX artifacts) |
| `automation/notify.py` | Slack + Discord 이중 알림 |
| `automation/sheets_tracker.py` | Google Sheets `pipeline_results` / `data_coverage` 시트 관리 |
| `automation/notion_reporter.py` | Notion Database 실험 페이지 자동 생성 |
| `automation/github_release.py` | GitHub Release 생성 + 모델 파일 자동 첨부 |
| `automation/config.py` | 환경변수 중앙 관리 |
| `automation/requirements.txt` | mlflow, slack-sdk, gspread, notion-client, PyGithub 등 |
| `automation/.env.example` | 설정 가이드 |
| `.github/workflows/daily_pipeline.yml` | 매일 02:00 KST 자동 학습 (self-hosted runner) |
| `.github/workflows/release.yml` | `v*` 태그 Push 시 릴리즈 자동화 |

## 사용법

```bash
# 의존성 설치
pip install -r automation/requirements.txt

# 환경변수 설정
cp automation/.env.example automation/.env

# MLflow 서버 (로컬)
mlflow server --host 0.0.0.0 --port 5000

# 파이프라인 실행
python automation/pipeline_runner.py --models conv1d tranad dcdetect --epochs 10

# 릴리즈 포함
python automation/pipeline_runner.py --models conv1d tranad --epochs 10 --release --tag v0.2.0
```

## GitHub Secrets 필요

레포 Settings → Secrets에 등록 필요:
`SLACK_BOT_TOKEN`, `DISCORD_WEBHOOK_URL`, `NOTION_API_KEY`, `NOTION_DATABASE_ID`, `GSHEETS_SPREADSHEET_ID`, `GH_PAT`, `MLFLOW_TRACKING_URI`

## Test plan

- [ ] `python automation/pipeline_runner.py --eval-only --models conv1d` 실행 확인
- [ ] `.env` 없을 때 graceful skip 확인 (각 서비스 비활성 처리)
- [ ] MLflow UI (`http://localhost:5000`)에서 실험 런 확인
- [ ] GitHub Actions `daily_pipeline.yml` 수동 트리거 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)