### PR TITLE
dev-tooling: Semgrep MCP + agnix + skills + n8n weekly scan

### DIFF
--- a/.claude/skills/briefing/SKILL.md
+++ b/.claude/skills/briefing/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: briefing
+description: Generate a progress briefing or status report from recent commits, open PRs, and project context. Use when the user asks for a briefing, a status report, a summary of what changed, a standup, a weekly report, or "what happened recently". Reuses the existing commit_context digest and pulls PRs/issues via the github MCP or gh CLI, then writes a concise Korean report.
+---
+
+# Briefing / report (commit_context 재활용)
+
+최근 커밋 + 열린 PR + 프로젝트 맥락을 모아 간결한 한국어 보고서를 만든다.
+새 도구를 만들지 않고 이미 있는 `commit_context` + git/gh + Obsidian SSOT를 엮는다.
+
+## 1. 입력 수집
+
+```powershell
+# (a) 최근 커밋 다이제스트 — 기존 생성기 재활용
+python ml/automation/commit_context.py --print
+#     → ml/automation/context/commit_log.md
+
+# (b) 열린 PR / 최근 머지 (gh CLI 또는 github MCP)
+gh pr list --state open --limit 20
+gh pr list --state merged --limit 10
+
+# (c) 현재 작업 / 차기 할 일 (Obsidian SSOT, 있으면)
+python ml/automation/bootstrap.py
+```
+
+PR 본문·리뷰 맥락이 필요하면 github MCP(`get_pull_request`, `get_pull_request_comments`)로 보강한다.
+
+## 2. 보고서 구성 (한국어, 이모지 없이, 보고체)
+
+다음 섹션으로 합성한다:
+
+1. 기간 요약 — 무엇이 진행됐나 (커밋/PR 기준 3~5줄)
+2. 변경 하이라이트 — 주요 커밋/PR을 항목별로 (파일·영향 포함)
+3. 진행 중 / 차기 — 열린 PR, Obsidian 차기 할 일
+4. 리스크·블로커 — 있으면
+
+## 3. 출력처 선택
+
+- 화면 출력(기본) 또는
+- Obsidian 볼트 `운영/Daily Summary/` 노트로 저장 또는
+- Discord 요약 전송(기존 웹훅 `C:\scripts\discord_webhook.txt`)
+
+## 참고
+
+- 회의록을 함께 먹이려면 해당 .md 경로를 입력에 추가해 컨텍스트로 사용한다.
+- 정기 자동 브리핑이 필요하면 n8n 커맨드센터에 주간 워크플로로 묶는다
+  (이 스킬을 호출하는 형태). 상세: `dev-tooling/README.md`.

--- a/.claude/skills/config-lint/SKILL.md
+++ b/.claude/skills/config-lint/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: config-lint
+description: Lint AI-assistant config files (CLAUDE.md, SKILL.md, AGENTS.md, hooks, .mcp.json) with agnix before pushing or after editing them. Use when the user edits CLAUDE.md or a skill, asks to validate / check the Claude config, or wants to catch broken skill frontmatter, malformed MCP entries, oversized CLAUDE.md, or hook mistakes.
+---
+
+# Config lint (agnix)
+
+agnix는 AI 코딩 어시스턴트 설정 파일 전용 린터다. 이 레포는 큰 `CLAUDE.md` + 스킬 다수 +
+`.mcp.json` 을 유지하므로, 이들이 깨지면(스킬 frontmatter 오류, MCP 항목 오타, CLAUDE.md
+과대 등) 조용히 동작이 어긋난다. agnix가 정적으로 잡아준다(422룰).
+
+## 실행
+
+```powershell
+# 레포 전체 설정 파일 린트
+npx agnix .
+
+# 특정 파일만
+npx agnix CLAUDE.md
+npx agnix .claude/skills/
+
+# 자동 수정 가능한 항목 적용
+npx agnix . --fix
+```
+
+전역 설치돼 있으면 `agnix .` 로 바로 실행(이 머신은 `npm i -g agnix` 완료).
+
+## 언제 돌리나
+
+- `CLAUDE.md` 또는 `.claude/skills/*/SKILL.md` 를 수정한 직후
+- 새 스킬/MCP 항목 추가 후
+- 푸시 전 점검 (release-management 스킬과 함께)
+
+## 결과 해석
+
+- 카테고리별 경고/오류 + 라인 위치 + 권장 수정. `--fix` 로 자동수정 가능한 건 일괄 처리.
+- frontmatter `description` 누락/약함은 스킬 자동트리거 실패로 이어지므로 우선 수정한다.
+
+## 참고
+
+- 순수 Node 도구라 Windows 네이티브 동작.
+- 다중 어시스턴트(Claude/Cursor 등) 공용이지만 Claude Code 설정을 정면 지원.

--- a/.claude/skills/security-scan/SKILL.md
+++ b/.claude/skills/security-scan/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: security-scan
+description: Scan code for security vulnerabilities with Semgrep SAST. Use when the user asks to security-check, find vulnerabilities, run a security scan, audit code for injection / unsafe eval / hardcoded secrets / path traversal, or review a diff for security issues before committing or pushing. Covers Python and C++ in this repo. Complements pyright (types only) and GitHub code review.
+---
+
+# Security scan (Semgrep)
+
+Semgrep으로 코드의 보안 취약점을 정적 분석한다. pyright는 타입만 보므로(취약점 미탐지)
+이 스킬이 SAST 갭을 메운다. semgrep MCP(`.mcp.json` 의 `semgrep`)가 떠 있으면 그 도구를
+직접 호출해도 되고, 아래 CLI를 써도 된다.
+
+## 1. 변경분만 스캔 (커밋/푸시 전 권장)
+
+```powershell
+# 변경된 파일 목록 → semgrep 스캔
+$files = git diff --name-only HEAD
+uvx --from semgrep semgrep scan --config p/security-audit --config p/secrets $files
+```
+
+## 2. 특정 경로 / 전체 스캔
+
+```powershell
+# 파이썬 파이프라인만
+uvx --from semgrep semgrep scan --config p/python --config p/security-audit ml/
+
+# C++ 플러그인
+uvx --from semgrep semgrep scan --config p/c ais_ids_pi/src/
+
+# 비밀키/토큰 유출 점검 (공개 레포라 중요)
+uvx --from semgrep semgrep scan --config p/secrets .
+```
+
+## 3. 룰셋 가이드
+
+| 룰셋 | 용도 |
+|---|---|
+| `p/security-audit` | 범용 보안 취약점(injection, SSRF, 안전하지 않은 역직렬화 등) |
+| `p/secrets` | 하드코딩된 토큰/키/자격증명 |
+| `p/python` `p/c` | 언어별 베스트프랙티스 |
+| `--config auto` | 언어 자동 감지(레지스트리 룰, 로그인 시 Pro 룰 추가) |
+
+## 4. 결과 해석
+
+- `Findings: N` 줄에서 탐지 건수 확인. 각 finding은 파일:라인 + 룰ID + 설명.
+- 오탐이면 해당 라인 위에 `# nosemgrep: <rule-id>` 주석으로 무시.
+- JSON 출력: `--json --output result.json` (n8n/스크립트 연동용).
+
+## 참고
+
+- Windows 네이티브에서 동작 확인됨(WSL 불필요, semgrep 1.166+).
+- 주간 자동 스캔은 n8n 커맨드센터 워크플로 `JB - Semgrep Weekly` 가 담당
+  (결과를 Discord로 요약 전송). 상세: `dev-tooling/README.md`.
+- 첫 실행 시 uvx가 semgrep(약 50MB)을 받으므로 수십 초 지연될 수 있다.

--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,9 @@ build/
 ml/pipeline_config.json
 ml/google_credentials.json
 
+# 프로젝트 MCP 설정 — 실제 토큰 포함하므로 추적 금지(공개 레포). 템플릿은 .mcp.json.example 만 커밋.
+.mcp.json
+
 # caveman-compress backups
 *.original.md
 

--- a/.mcp.json.example
+++ b/.mcp.json.example
@@ -1,0 +1,35 @@
+{
+  "_comment": "Copy this file to .mcp.json (gitignored) and fill in real tokens. Claude Code expands ${VAR} from your environment, or you may paste literal values into the local .mcp.json. Never commit real tokens — the repo is public.",
+  "mcpServers": {
+    "obsidian": {
+      "command": "npx",
+      "args": ["-y", "mcp-obsidian"],
+      "env": {
+        "OBSIDIAN_API_KEY": "${OBSIDIAN_API_KEY}",
+        "OBSIDIAN_HOST": "127.0.0.1",
+        "OBSIDIAN_PORT": "27124",
+        "OBSIDIAN_PROTOCOL": "https"
+      }
+    },
+    "sequential-thinking": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-sequential-thinking"]
+    },
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_PERSONAL_ACCESS_TOKEN}"
+      }
+    },
+    "context7": {
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp"
+    },
+    "semgrep": {
+      "command": "uvx",
+      "args": ["semgrep-mcp"],
+      "_note": "SAST security scanning. Requires uv/uvx on PATH (https://docs.astral.sh/uv/). On Windows use the full path to uvx.exe if it is not on the agent PATH."
+    }
+  }
+}

--- a/ais_ids_pi/README.md
+++ b/ais_ids_pi/README.md
@@ -1,0 +1,44 @@
+# ais_ids_pi — OpenCPN AIS anomaly-detection plugin (C++)
+
+OpenCPN plugin that runs the trained ML model (ONNX) on live AIS tracks and flags anomalous
+ships. This is the deployment target of the ML pipeline in `../ml/`.
+
+## Build & deploy (native Linux only)
+
+Windows is used only for ML training; the plugin is built and deployed on native Linux
+(Ubuntu 24.04 / noble). WSL is not the target.
+
+```bash
+git submodule update --init --recursive   # opencpn-libs is a submodule (first build)
+./local-build-package.sh                   # from this directory
+# Output: ais_ids_pi-<version>-ubuntu-x86_64-24.04-noble.tar.gz
+```
+
+ONNX Runtime is bundled under `onnxruntime/{include,lib}`.
+
+## Layout
+
+| Path | Purpose |
+|---|---|
+| `src/ais_ids.cpp` | Plugin main source |
+| `include/ais_ml.h` | ML interface; holds `ML_FEATURE_COUNT` and `[AUTO:feat_block]`/`[AUTO:push_decl]` codegen markers |
+| `src/ais_ml.cpp` | ML inference impl; `[AUTO:push_impl]` marker |
+| `data/` | Bundled model: `model.onnx`, `scaler.json`, `threshold.txt` |
+| `local-build-package.sh` | cmake + make package build |
+| `opencpn-libs/` | git submodule |
+| `onnxruntime/` | bundled ONNX Runtime |
+
+## Model deployment
+
+The pipeline exports `model_{name}.onnx` / `scaler_{name}.json` / `threshold_{name}.txt`; the
+plugin loads fixed names `model.onnx` / `scaler.json` / `threshold.txt`. Runtime load location
+is `GetpPrivateApplicationDataLocation()/plugins/ais_ids_pi/data/` (on Linux
+`~/.opencpn/plugins/ais_ids_pi/data/`). `local-build-package.sh` installs `data/` there.
+
+`ML_FEATURE_COUNT` (in `include/ais_ml.h`) must match the deployed model's feature count.
+The orchestrator auto-patches the `[AUTO:*]` regions via `ml/core/patch_plugin.py` on FE adoption.
+
+## See also
+
+- Project rules and the full plugin/patch/build details: root `CLAUDE.md`.
+- ML pipeline that produces the model: `../ml/README.md`.

--- a/dev-tooling/README.md
+++ b/dev-tooling/README.md
@@ -1,0 +1,74 @@
+# dev-tooling — Claude 중심 개발/자동화 도구 세팅
+
+이 디렉토리는 JB-Pirate-King 팀의 Claude Code 중심 개발 워크플로를 강화하는 도구 세팅을
+버전관리한다. 무료·오픈소스만 사용한다. 2026-06-17 도입.
+
+도구 선정은 deep-research(다중 소스 + 적대적 검증)로 조사 후, 이미 쓰던 것
+(Repomix, pyright-lsp, llms.txt, 자체 스킬 7개, commit_context, n8n 커맨드센터,
+IDA/obsidian/sheets/github/context7 MCP, LM Studio)을 제외하고 갭을 메우는 것만 채택했다.
+
+## 채택한 도구
+
+### 1. Semgrep MCP — 보안 정적분석(SAST)
+- 무엇: 공식 MIT 라이선스 MCP 서버. SAST 5,000+ 룰로 코드 취약점 탐지.
+- 왜: pyright는 타입만 본다. injection / 안전하지 않은 eval / 하드코딩 비밀키 등
+  보안 취약점은 못 잡는다. Semgrep이 그 갭을 메운다(AIS 이상탐지·리버싱 팀에 직결).
+- 설치: `uvx semgrep-mcp` (uv 필요). Windows 네이티브 동작 확인(semgrep 1.166+, WSL 불필요).
+- Claude 연동: `.mcp.json` 의 `semgrep` 항목(템플릿은 루트 `.mcp.json.example`).
+- 온디맨드 사용: 스킬 `security-scan` (`.claude/skills/security-scan`).
+- 자동화: n8n 워크플로 `JB - Semgrep Weekly` (주 1회 레포 스캔 → Discord 요약).
+
+### 2. agnix — AI 설정 파일 린터
+- 무엇: CLAUDE.md / SKILL.md / AGENTS.md / hooks / .mcp.json 전용 정적 린터(422룰, MIT/Apache-2.0).
+- 왜: 큰 CLAUDE.md + 스킬 다수를 유지하는 팀. frontmatter 오류·MCP 오타·CLAUDE.md 과대 등을
+  조용히 깨지기 전에 잡는다.
+- 설치: `npm i -g agnix` (순수 Node, Windows 네이티브).
+- 사용: 스킬 `config-lint` (`.claude/skills/config-lint`). `npx agnix .` / `--fix`.
+
+### 3. 브리핑/보고서 — 기존 자산 재활용
+- 새 도구 없이 `commit_context` + git/gh + Obsidian SSOT를 엮어 진행 보고서를 생성.
+- 사용: 스킬 `briefing` (`.claude/skills/briefing`).
+
+## n8n 커맨드센터 연계
+
+백그라운드 자동화는 n8n(`http://localhost:5678`)이 단일 GUI로 관리한다(이 머신).
+운영 상세 문서는 `C:\scripts\README-commandcenter.md`(로컬, 머신 고유).
+참조용 워크플로 정의 사본은 `dev-tooling/n8n/` 에 둔다.
+
+| n8n 워크플로 | 스케줄(KST) | 동작 |
+|---|---|---|
+| JB - Notion Vault Sync | 09:00, 18:00 | Notion 자료 → git team-vault 미러 |
+| JB - Daily PM Snapshot | 18:00 | Sheets → Obsidian Daily Summary + Discord |
+| JB - Ops Nightly | 21:30 | 야간 운영 점검 → Discord |
+| JB - Semgrep Weekly | 월 09:00 | 레포 보안 스캔 → Discord 요약 (신규) |
+
+> n8n은 pm2가 데몬으로 상시 구동(콘솔 비의존). 켜고/끄기·즉시실행·이력은 GUI에서.
+
+## 협업 연동 (Slack/Discord) — 준비 완료, 활성화 대기
+
+Claude를 팀원처럼 채팅에서 구동하는 연동은 토큰만 넣으면 되도록 준비했다.
+가이드: `dev-tooling/slack-discord-setup.md`. (korotovsky slack-mcp / OpenACP, 둘 다 MIT.)
+
+## 보류한 도구 (이유)
+
+| 도구 | 보류 이유 |
+|---|---|
+| Claude Squad | tmux 의존 → Windows에서 WSL2 필요 |
+| RuFlo (ex-Claude-Flow) | 100+ 에이전트 전제, 2인엔 과대 |
+| Auto-Claude/Aperant | Electron 앱, 유지보수 모드(3.0 대기) |
+| Vibe Kanban | 서비스 종료 중(코드만 잔존) |
+| SonarQube MCP | Docker + 인스턴스 필요, OSS 경로 조건부 → Semgrep이 우위 |
+
+병렬·멀티에이전트는 이미 쓰는 git worktree + Claude Code의 Workflow/서브에이전트로 충분.
+
+## 디렉토리
+
+```
+dev-tooling/
+├── README.md                  이 문서
+├── slack-discord-setup.md     협업 연동 준비 가이드(토큰만 입력하면 활성화)
+└── n8n/                       n8n 워크플로 정의 참조 사본(머신 고유 경로 포함)
+```
+
+관련 스킬: `.claude/skills/{security-scan,config-lint,briefing}`.
+MCP 템플릿: 루트 `.mcp.json.example` (실제 `.mcp.json` 은 비밀키 때문에 gitignore).

--- a/dev-tooling/n8n/README.md
+++ b/dev-tooling/n8n/README.md
@@ -1,0 +1,34 @@
+# n8n 워크플로 (참조 사본)
+
+이 디렉토리는 n8n 커맨드센터 워크플로 정의의 **버전관리용 참조 사본**이다.
+실제로 동작하는 워크플로는 운영 머신의 `C:\scripts\n8n_workflows\` 에서 n8n(`C:\Users\pc\.n8n`)으로
+임포트되어 돈다. 운영 상세 문서: 운영 머신의 `C:\scripts\README-commandcenter.md`.
+
+머신 고유 경로(`C:\scripts\*.bat`)를 포함하므로 다른 머신에서 그대로 쓰진 못하고, 구조 참고용이다.
+
+## 워크플로
+
+| 파일 | 스케줄(KST) | Execute Command | 동작 |
+|---|---|---|---|
+| `jb_notion_vault_sync.json` | 매일 09:00, 18:00 | `notion_team_vault_sync.bat` | Notion 자료 → git team-vault 미러 |
+| `jb_daily_pm_snapshot.json` | 매일 18:00 | `daily_pm_snapshot.bat` | Sheets → Obsidian Daily Summary + Discord |
+| `jb_ops_nightly.json` | 매일 21:30 | `ops_nightly.bat` (ops_graph.py) | 야간 운영 점검 → Discord |
+| `jb_semgrep_weekly.json` | 매주 월 09:00 | `semgrep_scan.bat` | 레포 보안 스캔(Semgrep) → Discord 요약 |
+
+각 워크플로 = Schedule Trigger(Asia/Seoul) → Execute Command(기존 .bat 호출).
+
+## 핵심 운영 메모
+
+- n8n은 pm2가 데몬으로 상시 구동(`pm2 status` / `pm2 restart n8n`). 콘솔 비의존.
+- 부팅/로그온 복구: Task Scheduler `JB-n8n` → `pm2 resurrect`.
+- 환경변수: `NODES_EXCLUDE=[]`(Execute Command 노드 허용), `GENERIC_TIMEZONE=Asia/Seoul`,
+  `N8N_USER_FOLDER=C:/Users/pc`.
+
+## 재임포트
+
+```
+set PATH=C:\Program Files\nodejs;C:\Users\pc\AppData\Roaming\npm;%PATH%
+set NODES_EXCLUDE=[]
+n8n import:workflow --separate --input="C:\scripts\n8n_workflows"
+n8n publish:workflow --id=<id>   (list:workflow 로 확인)
+```

--- a/dev-tooling/n8n/jb_daily_pm_snapshot.json
+++ b/dev-tooling/n8n/jb_daily_pm_snapshot.json
@@ -1,0 +1,41 @@
+{
+  "name": "JB - Daily PM Snapshot",
+  "nodes": [
+    {
+      "parameters": {
+        "rule": {
+          "interval": [
+            { "field": "cronExpression", "expression": "0 18 * * *" }
+          ]
+        }
+      },
+      "id": "sched-pm-snapshot",
+      "name": "Schedule 18:00",
+      "type": "n8n-nodes-base.scheduleTrigger",
+      "typeVersion": 1.2,
+      "position": [0, 0]
+    },
+    {
+      "parameters": {
+        "command": "C:\\scripts\\daily_pm_snapshot.bat"
+      },
+      "id": "exec-pm-snapshot",
+      "name": "Run daily_pm_snapshot.bat",
+      "type": "n8n-nodes-base.executeCommand",
+      "typeVersion": 1,
+      "position": [260, 0]
+    }
+  ],
+  "connections": {
+    "Schedule 18:00": {
+      "main": [
+        [ { "node": "Run daily_pm_snapshot.bat", "type": "main", "index": 0 } ]
+      ]
+    }
+  },
+  "active": false,
+  "settings": {
+    "timezone": "Asia/Seoul",
+    "executionOrder": "v1"
+  }
+}

--- a/dev-tooling/n8n/jb_notion_vault_sync.json
+++ b/dev-tooling/n8n/jb_notion_vault_sync.json
@@ -1,0 +1,42 @@
+{
+  "name": "JB - Notion Vault Sync",
+  "nodes": [
+    {
+      "parameters": {
+        "rule": {
+          "interval": [
+            { "field": "cronExpression", "expression": "0 9 * * *" },
+            { "field": "cronExpression", "expression": "0 18 * * *" }
+          ]
+        }
+      },
+      "id": "sched-notion-vault",
+      "name": "Schedule 09:00 + 18:00",
+      "type": "n8n-nodes-base.scheduleTrigger",
+      "typeVersion": 1.2,
+      "position": [0, 0]
+    },
+    {
+      "parameters": {
+        "command": "C:\\scripts\\notion_team_vault_sync.bat"
+      },
+      "id": "exec-notion-vault",
+      "name": "Run notion_team_vault_sync.bat",
+      "type": "n8n-nodes-base.executeCommand",
+      "typeVersion": 1,
+      "position": [260, 0]
+    }
+  ],
+  "connections": {
+    "Schedule 09:00 + 18:00": {
+      "main": [
+        [ { "node": "Run notion_team_vault_sync.bat", "type": "main", "index": 0 } ]
+      ]
+    }
+  },
+  "active": false,
+  "settings": {
+    "timezone": "Asia/Seoul",
+    "executionOrder": "v1"
+  }
+}

--- a/dev-tooling/n8n/jb_ops_nightly.json
+++ b/dev-tooling/n8n/jb_ops_nightly.json
@@ -1,0 +1,41 @@
+{
+  "name": "JB - Ops Nightly",
+  "nodes": [
+    {
+      "parameters": {
+        "rule": {
+          "interval": [
+            { "field": "cronExpression", "expression": "30 21 * * *" }
+          ]
+        }
+      },
+      "id": "sched-ops-nightly",
+      "name": "Schedule 21:30",
+      "type": "n8n-nodes-base.scheduleTrigger",
+      "typeVersion": 1.2,
+      "position": [0, 0]
+    },
+    {
+      "parameters": {
+        "command": "C:\\scripts\\ops_nightly.bat"
+      },
+      "id": "exec-ops-nightly",
+      "name": "Run ops_nightly.bat",
+      "type": "n8n-nodes-base.executeCommand",
+      "typeVersion": 1,
+      "position": [260, 0]
+    }
+  ],
+  "connections": {
+    "Schedule 21:30": {
+      "main": [
+        [ { "node": "Run ops_nightly.bat", "type": "main", "index": 0 } ]
+      ]
+    }
+  },
+  "active": false,
+  "settings": {
+    "timezone": "Asia/Seoul",
+    "executionOrder": "v1"
+  }
+}

--- a/dev-tooling/n8n/jb_semgrep_weekly.json
+++ b/dev-tooling/n8n/jb_semgrep_weekly.json
@@ -1,0 +1,42 @@
+{
+  "id": "jbsemgrepwk00001",
+  "name": "JB - Semgrep Weekly",
+  "nodes": [
+    {
+      "parameters": {
+        "rule": {
+          "interval": [
+            { "field": "cronExpression", "expression": "0 9 * * 1" }
+          ]
+        }
+      },
+      "id": "sched-semgrep-weekly",
+      "name": "Schedule Mon 09:00",
+      "type": "n8n-nodes-base.scheduleTrigger",
+      "typeVersion": 1.2,
+      "position": [0, 0]
+    },
+    {
+      "parameters": {
+        "command": "C:\\scripts\\semgrep_scan.bat"
+      },
+      "id": "exec-semgrep-weekly",
+      "name": "Run semgrep_scan.bat",
+      "type": "n8n-nodes-base.executeCommand",
+      "typeVersion": 1,
+      "position": [260, 0]
+    }
+  ],
+  "connections": {
+    "Schedule Mon 09:00": {
+      "main": [
+        [ { "node": "Run semgrep_scan.bat", "type": "main", "index": 0 } ]
+      ]
+    }
+  },
+  "active": false,
+  "settings": {
+    "timezone": "Asia/Seoul",
+    "executionOrder": "v1"
+  }
+}

--- a/dev-tooling/slack-discord-setup.md
+++ b/dev-tooling/slack-discord-setup.md
@@ -1,0 +1,57 @@
+# 협업 연동 (Slack / Discord) — 활성화 가이드
+
+목표(로드맵 3번): 슬랙/디스코드 채팅에서 Claude를 팀원처럼 구동, 또는 Claude가 채팅을
+읽고/쓰게 한다. 둘 다 무료·MIT이며, 본인/팀원의 토큰만 넣으면 활성화된다(설치는 npx라 사전설치 불필요).
+
+두 가지 보완적 선택지가 있다. 용도가 다르니 필요에 맞춰 고른다.
+
+## A. korotovsky/slack-mcp-server — Claude가 Slack을 읽고/쓰기
+
+Claude Code가 Slack 채널을 읽고 메시지를 보내는 MCP 서버. 워크스페이스 관리자 승인 불필요
+(브라우저 토큰 사용). 두 팀원이 각자 본인 토큰을 넣으면 된다.
+
+### 토큰 추출(브라우저)
+1. 브라우저로 Slack 워크스페이스(1hc0.slack.com) 로그인.
+2. 개발자도구(F12) → Application/Storage:
+   - Cookies 에서 `d` 쿠키 값 = `SLACK_MCP_XOXD_TOKEN` (xoxd-...)
+   - Local Storage 또는 콘솔 `JSON.parse(localStorage.localConfig_v2).teams` 에서 `token`(xoxc-...) = `SLACK_MCP_XOXC_TOKEN`
+
+### .mcp.json 항목(추가)
+```json
+"slack": {
+  "command": "npx",
+  "args": ["-y", "slack-mcp-server@latest", "--transport", "stdio"],
+  "env": {
+    "SLACK_MCP_XOXC_TOKEN": "xoxc-...",
+    "SLACK_MCP_XOXD_TOKEN": "xoxd-..."
+  }
+}
+```
+주의: 브라우저 토큰은 로그아웃/비번변경/세션만료 시 무효 → 갱신 필요.
+
+## B. OpenACP — 채팅에서 Claude Code를 "구동"
+
+Slack/Discord/Telegram 스레드에서 Claude Code(및 28+ ACP 에이전트)를 돌리는 자체호스팅
+브리지(MIT). "클라우드 릴레이 없음 — 내 머신, 내 키". 채팅이 곧 에이전트 제어판이 된다.
+
+### 설치/실행
+```powershell
+npx -y @openacp/cli
+# 최초 실행 시 대화형 설정: 플랫폼(Slack/Discord) 선택 + 봇 토큰 입력
+```
+
+### 필요한 것
+- Discord: Discord Developer Portal에서 봇 생성 → 봇 토큰 + 채널에 초대. (스레드 세션·슬래시커맨드 Stable)
+- Slack: Socket Mode 앱 토큰. (채널/스레드 세션 Stable)
+
+상세 설정은 https://openacp.ai/ 참조. 봇 토큰만 발급하면 된다.
+
+## 어느 걸 쓰나
+- "Claude가 우리 Slack을 읽고 알림/요약을 올리게" → A(slack-mcp).
+- "폰/채팅에서 Claude Code에게 작업을 시키고 결과를 받기" → B(OpenACP).
+- 둘은 병행 가능(용도가 다름).
+
+## 현재 상태
+- 미설치(npx 실행형이라 설치 불필요). 토큰 미입력 → 비활성.
+- 기존 Discord 웹훅(`C:\scripts\discord_webhook.txt`)은 알림 송신용으로 계속 동작 중.
+- 메모리상 Slack 워크스페이스 채널 `C0B6RF2H79R` 존재.

--- a/llms.txt
+++ b/llms.txt
@@ -13,6 +13,7 @@
 - [프로젝트 컨텍스트·규칙](CLAUDE.md)
 - [ML 파이프라인 개요](ml/README.md)
 - [팀 자료 맵](team-vault/README.md)
+- [개발/자동화 도구 세팅](dev-tooling/README.md): Semgrep MCP(보안스캔)·agnix(설정린트)·n8n 커맨드센터·스킬(security-scan/config-lint/briefing). MCP 템플릿은 `.mcp.json.example`.
 
 ## 코드 진입점
 


### PR DESCRIPTION
## 개요
Claude Code 중심 개발 워크플로 강화 도구를 무료·OSS만 골라 도입했다. deep-research(다중소스+적대적검증)로 조사 후, 이미 쓰던 것(Repomix, pyright, 스킬 7개, commit_context, MCP들)은 제외하고 갭만 채택. 전부 네이티브 Windows에서 검증.

## 변경
- **Semgrep MCP** (보안 SAST) — pyright가 못 보는 취약점 갭. `.mcp.json.example` 에 연동, 온디맨드 `security-scan` 스킬, 주간 n8n 워크플로.
- **agnix** — CLAUDE.md/SKILL.md/hooks/.mcp.json 린터. `config-lint` 스킬.
- **briefing 스킬** — commit_context 재활용 진행보고.
- **n8n `JB - Semgrep Weekly`** — 주 1회 보안스캔 → Discord. 참조 사본 `dev-tooling/n8n/`.
- **비밀키 위생** — `.mcp.json` gitignore, 템플릿 `.mcp.json.example` 만 커밋(레포 PUBLIC).
- **문서** — `dev-tooling/README.md`, Slack/Discord 활성화 가이드(토큰 대기), `ais_ids_pi/README.md`, `llms.txt` 색인.

## 검증
- Semgrep 네이티브 Windows 스캔 OK(1.166), n8n 워크플로 4개 active.
- agnix: 새 스킬 0 errors/0 warnings.
- 변경 파일 비밀키 스캔(p/secrets): 0 findings.

## 팀원(heahgo) 후속
- `npm i -g agnix`, uv/uvx 설치(Semgrep MCP용).
- `.mcp.json.example` → `.mcp.json` 복사 후 토큰 입력.
- (선택) Slack/Discord 협업 연동: `dev-tooling/slack-discord-setup.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)