### PR TITLE
feat(skills): brief + read-docs + change-report 회의록 확장 (+ orchestrator 개편)

### DIFF
--- a/.claude/skills/brief/SKILL.md
+++ b/.claude/skills/brief/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: brief
+description: Generate a Korean progress briefing for the professor/advisor and publish it to Notion. Folds in ALL PR context + latest meeting notes (회의록) + experiment results + any files you point at, then writes a 진행·성과·계획 briefing (not a code changelog) and posts it as a dated Notion page. Use when the user says "교수님 브리핑", "브리핑", "주간보고", "교수 보고", "advisor briefing", "progress briefing".
+---
+
+# brief — 교수님 브리핑 페이지 자동 생성 (한글, Notion 게시)
+
+"PR 전체 맥락 + 최신 회의록 + 파일 → 전부 먹이고 → 교수 보고서 → 딸깍"을 한 스킬로. `change-report`(개발 changelog, 영어, 코드 디테일)와 **다름**: 이건 **한글 진행 브리핑** — 무엇을 했고, 성과 지표는 어떻고, 회의 결정을 어떻게 반영했고, 다음에 뭘 하는지. 코드 함수명/diff는 최소화하고 결과·의미 중심.
+
+## Hard safety rules
+
+- **읽기 전용 (git/GitHub/Sheets/파일).** `git log`/`git diff`/`gh ... view`/파일 읽기만. commit·push·stage·release 안 함.
+- **오케스트레이터 run 중엔 실행 금지** (공유 워킹트리). 불확실하면 `ml/logs/` 최신 로그 mtime + python 프로세스부터 확인.
+- **team-vault/ 는 읽기전용 Notion 미러** — 읽기만, 쓰기 금지.
+- **출력 언어 = 한글.** 교수님 대상. 표·수치는 그대로, 서술은 한글.
+- **Notion 쓰기는 메인 컨텍스트에서** (제한 서브에이전트는 MCP 접근 없음).
+
+## Step 1 — 소스 수집 (PR 전체 맥락 + 회의록 + 실험결과 + 파일)
+
+기간 결정: 직전 브리핑(있으면 그 날짜) ~ HEAD, 또는 사용자가 준 범위. 날짜는 `git log -1 --format=%cd --date=short`.
+
+**A. 코드/PR 전체 맥락** (요약용, 디테일 아님):
+- `git log --oneline <since>..HEAD` — 커밋 타임라인.
+- `gh pr list --state merged --limit 20` → 각 핵심 PR은 `gh pr view <n> --json title,body,mergedAt,comments` 로 **본문+논의까지** (네 말의 "PR 모든 맥락"). gh 미인증이면 로컬 로그만 쓰고 보고서에 명시.
+
+**B. 최신 회의록**:
+- 우선순위 ① 사용자가 준 경로(파일/폴더) → ② 폴백 `team-vault/자료/**/*회의록*.md` 최근순.
+- 추출: 결정사항, 액션아이템(담당+할일), 마감.
+- 없으면 한 줄(`회의록 없음`) 찍고 진행.
+
+**C. 실험결과/지표**:
+- 루트 `README.md`의 Run Results 블록(검출률 FP=1/5/10, threshold, 시나리오) 읽기.
+- `ml/deploy/{branch}/` per-run report 또는 `ml/.pipeline_tmp/` 최신 결과 JSON 있으면 수치 인용.
+- (선택) Google Sheets — 비용/인증 있으면만. 없으면 건너뜀.
+
+**D. 추가 파일**: 사용자가 지목한 파일 경로 있으면 읽어서 맥락 반영.
+
+## Step 2 — 브리핑 합성 (고정 한글 포맷)
+
+아래 구조·순서 그대로. 내용 없는 섹션만 생략(생략 사실은 언급 안 함).
+
+```
+# 교수님 브리핑 — <YYYY-MM-DD>
+
+> <한 줄 핵심: 이번 기간 가장 중요한 진전>
+> 기간: <시작>~<끝> · 커밋 <N> · 머지 PR <N>
+
+## 이번 기간 진행
+<2~4문장 서술. 무엇을 왜 했는지. 리스트 아님.>
+
+## 주요 성과
+- <항목>: <수치/결과 — 예: FP=1% 검출률 56.6%→81.8%(+25.3pp)>
+
+## 회의 반영              (회의록 있을 때만)
+출처: <회의록 파일 + 날짜>
+- ✅ 반영: <결정> → <실제 한 일>
+- ⬜ 미반영: <결정 중 아직 안 된 것>
+
+## 다음 계획
+- [ ] <다음 기간 할 일 / 마일스톤>
+
+## 리스크 · 이슈           (있을 때만)
+- <막힌 점 / 결정 필요 사항>
+```
+
+**규칙:**
+- 핵심 한 줄 + 기간 줄 필수. 나머지는 내용 게이팅.
+- 교수 대상 → 코드 함수명/플래그 남발 금지. 결과와 의미로. 꼭 필요하면 괄호로 한 번만.
+- 수치는 구체적으로(검출률·pp·threshold). 과장·군더더기·hedging 금지.
+- 과거형 서술, 한글. 한 항목 한 줄. CHANGELOG/백업은 최신이 위.
+
+## Step 3 — Notion 게시 (Notion MCP, 주 경로)
+
+> notify.py(내부 integration 토큰) 경로는 멤버 권한에서 parent 페이지 미공유로 **404 날 수 있음**. 그래서 이 스킬은 **사용자 OAuth Notion MCP**로 게시한다(본인 권한이면 멤버로도 됨).
+
+1. MCP 미인증이면: 사용자에게 `/mcp` → "claude.ai Notion" 인증 요청. 인증돼야 `notion-create-pages` 등이 뜸.
+2. 부모 페이지 찾기: `notion-search`로 **"교수님 브리핑"**(또는 "브리핑") 페이지 검색.
+   - 있으면 그 페이지 id를 부모로.
+   - 없으면(첫 실행): 사용자에게 "어느 페이지 아래 만들까?" 한 번 확인 → 그 밑에 `notion-create-pages`로 컨테이너 페이지 1개("교수님 브리핑") 생성 후 재사용. (정해지면 이후엔 안 물음.)
+3. `notion-create-pages`:
+   - parent = 위 페이지 id (`{"type":"page_id","page_id":"..."}`)
+   - 하위 페이지 1개, properties.title = `교수님 브리핑 — <date>`, icon 예 `🎓`.
+   - content = Step 2 본문에서 **H1 제목 줄 제외**한 마크다운(제목은 properties로).
+4. 생성된 page url 확인 → Step 4에서 보고.
+
+## Step 4 — 로컬 백업 + 보고
+
+- 로컬 백업: `reports/brief_<date>.md`에 Step 2 전문 저장(폴더 없으면 생성). Notion 실패해도 안 날아가게.
+- 사용자에게 한글로: 핵심 한 줄 + 커버한 커밋/PR 수, Notion 페이지 생성됐는지(url) 또는 스킵 사유, 백업 파일 경로.
+- 커밋/푸시는 사용자 몫 — 자동 안 함.

--- a/.claude/skills/change-report/SKILL.md
+++ b/.claude/skills/change-report/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: change-report
-description: Detect code and GitHub changes and write a change report into Notion. Pulls local git diff+log and (if gh is authed) merged PRs/releases/issues, synthesizes a dated report, and publishes it as a Notion page (primary output), with a local CHANGELOG.md copy. Use when the user says "change report", "changelog", "what changed", "변경사항 정리", "릴리스 노트".
+description: Detect code and GitHub changes and write a change report into Notion. Pulls local git diff+log and (if gh is authed) merged PRs/releases/issues, optionally folds in meeting notes (회의록) to check decisions vs. actual code, synthesizes a dated report, and publishes it as a Notion page (primary output), with a local CHANGELOG.md copy. Use when the user says "change report", "changelog", "what changed", "변경사항 정리", "릴리스 노트", "회의록 보고서", "브리핑 보고서".
 ---
 
 # change-report — detect changes and write them up **into Notion**
@@ -14,6 +14,18 @@ Turns "what changed?" into a written artifact. Reads (never mutates) git + GitHu
 - **Notion publish is the intended action here** — the user wants every report on Notion. Do it without re-asking each run. BUT the first time in a session (or when the parent page is unknown), confirm WHICH Notion page/space to post under, then reuse it.
 - **Do the Notion write from the main context, not a subagent** (cavecrew/limited subagents have no MCP access).
 - Report prose: English (project convention). The spoken summary to the user: Korean.
+
+## Step 0 — Meeting notes (회의록), optional
+
+The roadmap wants reports to fold in "PR context **+ latest meeting notes** + files". Gather meeting notes when available so the report can check decisions against actual code.
+
+Source priority:
+1. **Path argument** — if the user passed a file/folder path (or names one), read those `.md` notes.
+2. **Fallback scan** — else glob `team-vault/자료/**/*회의록*.md` and take the most recent (by `last_synced` frontmatter or filename date). `team-vault/` is a read-only Notion mirror — read only, never write.
+
+From the notes, extract: decisions made, action items (owner + task), and any dated follow-ups. Hold these for Steps 2's `## 회의 맥락` and `## 정합성` sections.
+
+If no notes are found, print one line (`회의록 없음 — git/gh 변경만으로 보고서 생성`) and proceed; everything below is unchanged (backward compatible). Do not block on missing notes.
 
 ## Step 1 — Gather sources
 
@@ -43,6 +55,16 @@ Get the date from `git log -1 --format=%cd --date=short` (do not guess). Produce
 ## Summary
 <2–4 sentence plain-English overview: what changed and why it matters. No lists here.>
 
+## Meeting context      (omit unless Step 0 found notes)
+<source file + date>
+- <decision or action item from the notes, one per bullet>
+
+## Alignment            (omit unless Step 0 found notes)
+Meeting decisions vs. actual code changes this batch.
+- ✅ done: <decision> → <commit/PR that implements it>
+- ⬜ not done: <decision with no matching change>
+- ➕ unplanned: <code change not traceable to any decision>
+
 ## Code changes
 Grouped by area, one bullet per distinct change.
 - **orchestrator**: <what changed> (`file:func`, flags/nodes touched)
@@ -67,6 +89,7 @@ Grouped by area, one bullet per distinct change.
 
 **Format rules:**
 - Headline + Scope line are mandatory; everything else is section-gated by content.
+- `## Meeting context` + `## Alignment` appear only when Step 0 found notes; drop both otherwise (the report stays exactly as before).
 - Group Code changes by area: `orchestrator / pipeline_steps / feature_engineer / plugin / docs / config`. Drop empty areas.
 - Be concrete: name files (`ml/orchestrator.py`), functions/nodes (`_logged_node`, `fe_train`), flags (`--invent_rounds`). No filler, no praise, no hedging.
 - Past tense, English. One change per bullet. Newest report on top in CHANGELOG.md.

--- a/.claude/skills/read-docs/SKILL.md
+++ b/.claude/skills/read-docs/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: read-docs
+description: Read the project's real markdown docs and emit an area-grouped summary, skipping vendored library READMEs. Fans out parallel read-only agents so the main context stays small. Use when the user says "md 다 읽어", "문서 읽기", "문서 요약", "프로젝트 파악", "read docs", "read all the markdown".
+---
+
+# read-docs — read project docs, summarize by area, skip vendor noise
+
+Turns "read all the md files" into a repeatable, token-cheap action. Reads (never mutates) the repo's **own** markdown, ignores third-party vendored READMEs, and returns one area-grouped summary. Replaces doing it by hand every session.
+
+## Hard safety rules
+
+- **Read-only.** Read/Glob/Explore only. No edit, write, commit, or config change. This skill never mutates a file.
+- **team-vault/ is a read-only Notion mirror** — read it, never write it (next sync overwrites anything you'd add).
+- Spoken summary to the user: Korean. (Project docs themselves are English/Korean as-is — quote, don't translate.)
+
+## What counts as a "real" doc (include) vs vendor noise (exclude)
+
+**Exclude** (third-party, vendored — never read these):
+- `ais_ids_pi/opencpn-libs/**` (jsoncpp, libusb, muparser, plugin_dc, api-18/19/20/21, flatpak, WindowsHeaders …)
+- `ais_ids_pi/onnxruntime/**` (Privacy.md, README.md)
+
+Everything else under the repo is a real project/team doc.
+
+## Step 1 — Enumerate
+
+Glob `**/*.md` from repo root, then drop anything matching the exclude globs above. Report the count: `<N> real docs, <M> vendored skipped`. (Baseline at authoring time: ~21 real, ~17 vendored — if the numbers drift a lot, say so; new docs are fine.)
+
+## Step 2 — Read via parallel Explore agents (token-cheap)
+
+Do NOT read all files inline — that floods the main context. Instead fan out **Explore subagents in parallel** (one message, multiple Agent calls), one per group below. Tell each agent: read-only, return a compact factual summary (key facts + file refs), no recommendations.
+
+| Group | Files |
+|---|---|
+| root | `README.md`, `CLAUDE.md` |
+| ml | `ml/README.md`, `ml/PIPELINE.md` |
+| component | `s-c/Readme.md`, `aivdm_gen/README.md` |
+| team-vault research/ref | `team-vault/README.md`, `team-vault/SETUP-팀원.md`, `team-vault/자료.md`, `team-vault/자료/**/*.md` |
+| skills | `.claude/skills/*/SKILL.md` |
+
+If Step 1 found docs outside these groups, add them to the closest group (or a new "기타" group) — don't silently drop them.
+
+> Small-corpus shortcut: if only a handful of real docs exist (≲6), reading them inline is fine; skip the fan-out.
+
+## Step 3 — Emit area-grouped summary
+
+Output one Korean summary with a heading per group (root / ml / component / team-vault / skills). Per doc: 1–2 lines of substance (what it covers, key facts). End with: `벤더 <M>개 스킵 (opencpn-libs, onnxruntime)`. Keep the cross-cutting throughline if obvious (e.g. AIS 이상탐지 / DCdetector / OpenCPN 플러그인).

--- a/.claude/skills/repo-status/SKILL.md
+++ b/.claude/skills/repo-status/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: repo-status
+description: Report and review how the local repo diverges from its remotes (origin + upstream org). Fetches (read-only, never merges), computes ahead/behind per branch, lists unpushed/unpulled commits and working-tree state, then reviews the divergent diff for secrets, WIP, conflict risk, and code issues. Use when the user says "repo status", "remote diff", "local vs github", "원격 비교", "로컬 원격 차이", "동기화 상태", "변경 상황 보고".
+---
+
+# repo-status — report + review local ↔ remote divergence
+
+Answers "what's different between my local repo and GitHub, and is it safe to push/pull?" in one pass: a **status report** (what diverges) plus a **review** (what's risky in that divergence). Read-only — it inspects and recommends, it never mutates history.
+
+## Hard safety rules (read first)
+
+- **Read-only git only.** `git fetch` (no merge), `git log`, `git diff`, `git status`, `git rev-list`, `gh ... view/list`. **NEVER** push, pull, merge, rebase, reset, commit, stage, or create PRs. Recommend actions; let the user run them.
+- **`git fetch` only updates remote-tracking refs** — it does not touch the working tree or local branches. That is the one network call allowed.
+- **NEVER run while an orchestrator run is in progress** (shared working tree). If `ml/logs/` shows an active run or a `dcdetect_NNN` branch is checked out mid-run, STOP and tell the user.
+- Report prose to the user: Korean. Any code/diff snippets quoted verbatim.
+
+## Step 1 — Fetch + map remotes
+
+- `git remote -v` — enumerate remotes. This repo's convention: `origin` = personal fork (heahgo), `upstream` = org (`JB-Pirate-King/JB-Pirate-King`). `upstream` may be **detached/missing** — if so, note it and compare against `origin` only (do not add the remote yourself; tell the user the command if they want org comparison).
+- `git fetch --all --prune` — refresh remote-tracking refs (read-only, no merge).
+- `git rev-parse --abbrev-ref HEAD` — current branch.
+
+## Step 2 — Compute divergence
+
+For the current branch (and any branch the user named) against each relevant remote ref:
+
+- **ahead/behind**: `git rev-list --left-right --count HEAD...<remote>/<branch>` → `<ahead> <behind>`.
+- **unpushed** (local-only): `git log --oneline <remote>/<branch>..HEAD`.
+- **unpulled** (remote-only): `git log --oneline HEAD..<remote>/<branch>`.
+- **working tree**: `git status --porcelain` → split into staged / modified / untracked.
+- **file surface of the divergence**: `git diff --stat <remote>/<branch>...HEAD` (and `git diff --stat` for uncommitted).
+
+If both origin and upstream exist, do this for both (e.g. `origin/main` and `upstream/main`) — the gaps often differ.
+
+## Step 3 — Review the divergence
+
+Scan the divergent diff (unpushed commits + working-tree changes) and flag, one line each:
+
+- **Secret leak** — added/changed lines or newly-tracked files matching `notify_config.json`, `google_credentials.json`, `pipeline_config.json`, `.env`, or `token`/`secret`/`key`/`password` patterns. Cross-check `.gitignore` actually excludes them (`git check-ignore <path>`). This is the highest-priority finding.
+- **Conflict risk** — behind > 0 **and** working tree dirty, or unpushed + unpulled both non-empty (divergent histories → a plain push will be rejected, a pull may conflict).
+- **WIP / debris** — `TODO`/`FIXME`/`XXX`/`print(`-debug/commented-code added in the divergent diff; large or binary files; files that look accidentally staged.
+- **Code issues** — for a non-trivial code diff, optionally delegate to **`caveman:cavecrew-reviewer`** (pass the unpushed diff or changed files) for severity-tagged one-line findings. Skip for docs-only or tiny diffs.
+
+## Step 4 — Report
+
+Korean summary, in this order:
+
+1. **상태 한 줄**: `<branch>` is ahead N / behind M vs `origin` (and upstream if present), working tree clean/dirty.
+2. **미푸시 커밋** (local-only) — oneline list.
+3. **미수신 커밋** (remote-only) — oneline list.
+4. **파일 변경** — `--stat` surface (commits + uncommitted), grouped if large.
+5. **리뷰 경고** — Step 3 findings, secret-leak first. If none, say "경고 없음".
+6. **권장 액션** — concrete git commands (push / pull --rebase / open PR), but **do not run them** — the user decides.

--- a/.claude/skills/sync-docs/SKILL.md
+++ b/.claude/skills/sync-docs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sync-docs
-description: Update project documentation to match code changes. Fans out parallel agents to sync README.md, ml/README.md, and CLAUDE.md against the current diff. Use when the user says "sync docs", "update the docs", "docs 동기화", or after a code/structure change before pushing.
+description: Update project documentation to match code changes. Fans out parallel agents to sync README.md, ml/README.md, CLAUDE.md, and ml/PIPELINE.md against the current diff, and refreshes the LangGraph graph artifacts (PIPELINE.md mermaid block + ml/pipeline_langgraph.png) when the orchestrator graph changed. Use when the user says "sync docs", "update the docs", "docs 동기화", "그래프 갱신", or after a code/structure change before pushing.
 ---
 
 # sync-docs — keep docs in sync with code (parallel fan-out)
@@ -11,7 +11,7 @@ Enforces the project rule: *a code/structure change isn't "done" until README + 
 
 - **NEVER run while an orchestrator run is in progress.** Shared working tree -> the run's auto-commit would sweep staged changes. If `ml/logs/` shows an active run or a `dcdetect_NNN` branch is checked out mid-run, STOP and tell the user.
 - **Do NOT git commit / stage / rm.** This skill only edits doc files. Committing is the user's call.
-- **Docs language: English** (project convention). Only the final summary spoken to the user stays Korean.
+- **Docs language: English** (project convention) for README / ml/README / CLAUDE.md. `ml/PIPELINE.md` is a **Korean** doc — keep it Korean. Only the final summary spoken to the user stays Korean.
 
 ## Step 1 — Detect what changed
 
@@ -32,6 +32,7 @@ Decide which of these are affected (skip untouched ones):
 | `README.md` | top-level project overview, run results, high-level features |
 | `ml/README.md` | ML pipeline usage, commands, options, paths |
 | `CLAUDE.md` | architecture/state for a fresh session: nodes, flow, flags, gotchas |
+| `ml/PIPELINE.md` | LangGraph node-level detail: node catalog, routing, State, judge/gate behavior (Korean doc) |
 
 ## Step 3 — Fan out (parallel)
 
@@ -44,10 +45,35 @@ Each agent gets:
 
 Use `caveman:cavecrew-builder` for the markdown-file targets (bounded 1-file edits).
 
+**Language note:** README.md / ml/README.md / CLAUDE.md are **English**. `ml/PIPELINE.md` is the
+exception — it is a **Korean** doc; its agent must match the existing Korean wording/table style.
+
+## Step 3b — Refresh the graph artifacts (only if the orchestrator graph changed)
+
+Run this **in the main context** (it is a deterministic script + a single mermaid-block swap, not
+an LLM edit — no fan-out). **Skip entirely** if the diff did not touch the graph topology
+(`build_graph`, node/edge wiring, or `n_*` node set in `ml/orchestrator.py`) — do not churn the PNG.
+
+1. Extract the authoritative mermaid (always in sync with code):
+   ```
+   PYTHONUTF8=1 python -c "from ml.orchestrator import build_graph; print(build_graph().get_graph().draw_mermaid())"
+   ```
+2. Replace the ```` ```mermaid ```` code block in `ml/PIPELINE.md` (section "2. 구조도", the block
+   right after the `draw_mermaid()` regen note) with the freshly extracted source.
+3. Re-render the colored PNG (reuses the existing renderer — do not duplicate it):
+   ```
+   PYTHONUTF8=1 python -m ml.scripts.render_graph
+   ```
+   → refreshes `ml/pipeline_langgraph.png`. This also prints `[경고] 미분류 노드 …` if a new node
+   was added but not classified in `render_graph.py` GROUPS — **surface that warning to the user**
+   (it means `render_graph.py` GROUPS needs a one-line update). `draw_mermaid_png` calls mermaid.ink,
+   so on a network failure treat the PNG step as best-effort (skip, keep the mermaid-text refresh).
+
 ## Step 4 — Report
 
 After agents return, give the user a Korean summary:
 - which docs were updated and the key lines changed,
+- whether the graph artifacts were refreshed (mermaid block + PNG) or skipped (graph unchanged),
 - anything skipped (untouched) and why,
 - remind: `/change-report` for a changelog/release note if they want one,
 - remind: commit is their call (do not auto-commit).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+# 변경 보고서 — 2026-06-17
+
+> 오케스트레이터 judge 비용/수렴 개편(브랜치당 LLM 7→3) + Claude Code 스킬 3종 신규/확장.
+> 범위: origin/develop..HEAD + 미커밋 스킬작업 · 커밋 3개 · 머지된 PR 0개
+
+## 요약
+LangGraph 오케스트레이터를 시험-run 낭비 절감 방향으로 손봄: 브랜치당 Claude judge 호출이 7→3으로 줄고, 목표점수 상승이 멈추면 조기 수렴하며, judge 재시도 무한반복을 제한하고, 크래시 복구 가능한 체크포인트를 옵션으로 제공. 별도 커밋으로 노드 경계를 `tail -f`로 실시간 보는 node-IO 로그 싱크 추가. 도구 쪽은 스킬 3종 추가: `repo-status`(커밋됨), 이번 세션의 `read-docs`(신규), 회의록을 엮는 `change-report` 확장.
+
+## 코드 변경
+- **orchestrator**: judge 강등 — `JUDGE_ON`을 `{baseline, reco, fe}`로 제한; `new_branch/release/chain`은 pass-through; `build` judge는 `n_check_build`(commit_files>0 → continue)로 교체 — judge 호출 7→3 (`ml/orchestrator.py`, `ab72c39`).
+- **orchestrator**: 추세 기반 조기 수렴 — 최근 두 라운드의 `best_obj_gain`이 모두 ≤0이면 `route_after_fe`가 수렴, 신규 `state.obj_hist` 사용 (`ab72c39`).
+- **orchestrator**: judge 재시도 예산 — `claude_judge`가 `state.retry_count` 추적, `MAX_JUDGE_RETRY=2` 초과 시 verdict를 `continue`로 강등해 flap 루프 차단 (`ab72c39`).
+- **orchestrator**: `--persist` 플래그 — `_make_checkpointer`가 `SqliteSaver` 생성(인터럽트 게이트 대기 중 크래시 복구), 부재 시 경고와 함께 `MemorySaver`로 폴백 (`ab72c39`).
+- **orchestrator**: 비동기 Sheets — `log_sheet`가 `_SHEET_LOCK`으로 직렬화된 데몬 스레드에서 기록, 핫패스의 수초 블로킹 제거 (`ab72c39`).
+- **orchestrator**: 종료 경로 통합 — 미채택 stop이 하드 `user_stop` 대신 converge 게이트(정상 로깅/Sheets)로 라우팅 (`ab72c39`).
+- **orchestrator**: 실시간 node-IO 싱크 — 신규 `ml/logs/nodeio_{ts}.log`, `_node_line`/`_open_node_log`로 줄 단위 flush된 `[NODE→]/[NODE←]` 스트림; tee 로그·대용량 `nodes_{ts}.jsonl`과 분리 (`4856cea`).
+- **pipeline_steps**: `_fe_train_eval`가 `best_obj_gain` 반환 → 조기 수렴 `obj_hist`에 공급 (`ml/pipeline_steps.py`, `ab72c39`).
+- **docs / skills**: `repo-status` 스킬 추가 — 읽기전용 로컬↔원격 divergence 보고 + 리뷰(fetch만, push/pull/merge 안 함) (`.claude/skills/repo-status/SKILL.md`, `6791a8c`).
+- **docs / skills**: `read-docs` 스킬 추가 — repo 실문서 읽고 벤더 README 제외, Explore 병렬 fan-out으로 영역별 요약 (`.claude/skills/read-docs/SKILL.md`, 미커밋).
+- **docs / skills**: `change-report` 확장 — Step 0 회의록 수집 + `## 회의 맥락`/`## 정합성` 섹션(경로 인자 + `team-vault/자료/` 폴백) (`.claude/skills/change-report/SKILL.md`, 미커밋).
+
+## 영향받는 문서 / 후속작업
+- [ ] CLAUDE.md orchestrator 섹션 stale — 신규 `--persist` 플래그, `JUDGE_ON` 강등(7→3), `obj_hist` 조기수렴, `MAX_JUDGE_RETRY`, 비동기 Sheets → `/sync-docs` 실행.
+- [ ] `origin/develop`에 안 푼 커밋 3개; `read-docs`+`change-report` 스킬 변경 미커밋 — 커밋/푸시는 사용자 몫.
+- [ ] `--persist`는 `langgraph-checkpoint-sqlite` 필요; 부재 시 조용히 MemorySaver 폴백(크래시 복구 불가).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -294,11 +294,19 @@ live in `ml/pipeline_steps.py` (shared step library). Design diagram: `ml/pipeli
   `ml/dynamic_candidates.py` (gitignored) → `feature_engineer` loads + scans them. Convergence
   (no adoption) re-recommends from a different angle up to `--invent_rounds`. `--invent` defaults
   to **5** and is the ONLY candidate source — `CANDIDATE_FEATURES` is empty (no static pool).
-- **per-node claude judge** (`claude_judge` factory): each compute node is followed by a judge
-  node that runs `claude -p --output-format json` → `{assessment, verdict: continue|retry|stop, ...}`
-  → routing. Per-stage judging criteria injected via `STAGE_FOCUS`; model replies fenced in
+- **per-node claude judge** (`claude_judge` factory): a judge node that runs
+  `claude -p --output-format json` → `{assessment, verdict: continue|retry|stop, ...}` → routing.
+  Per-stage judging criteria injected via `STAGE_FOCUS`; model replies fenced in
   ```` ```json ```` are stripped (`_strip_code_fence`). Toggle per node via `JUDGE_ON` set;
-  `--no_judge` disables all.
+  `--no_judge` disables all. **Judge demotion (cost cut 7→3 LLM calls/branch)**: `JUDGE_ON` is now
+  `{"baseline", "reco", "fe"}` — only baseline (weak-scenario diagnosis), reco (candidate
+  dedup/validity), and fe (adoption/regression analysis) run a real `claude -p` judge.
+  `new_branch`/`release`/`chain` are pass-through (return `continue`, no LLM — their success is a
+  deterministic fact); `build` is replaced by a deterministic Python check node `n_check_build`
+  (`commit_files > 0` → `continue`, else `stop`), since an empty/partial build returns no exception.
+- **judge retry budget** (`MAX_JUDGE_RETRY = 2`): `claude_judge` tracks per-stage retry counts in
+  `state.retry_count` and downgrades a `retry` verdict to `continue` once a stage exceeds the limit,
+  preventing flap loops that were previously bounded only by `recursion_limit`.
 - **per-branch claude session**: `n_new_branch` issues a uuid; knowledge priming creates the
   session (`--session-id`), then judge/recommend/`claude_analyze` all `--resume` it — one
   accumulated conversation per branch, isolated across branches. Models per call type:
@@ -317,23 +325,42 @@ live in `ml/pipeline_steps.py` (shared step library). Design diagram: `ml/pipeli
   `run_{ts}.log`; each branch entry switches to its own `{branch}_{ts}.log`
   headed by a separator with the full claude session uuid.
 - **node in/out logging** (`_logged_node`): every graph node (compute + judge) is
-  wrapped to record its input `state` and output delta. Two sinks: ① compressed
+  wrapped to record its input `state` and output delta. Three sinks: ① compressed
   `┌─[NODE→]`/`└─[NODE←] name [branch] (elapsed)` one-liners into the tee log,
   ② full machine-parsable records into `ml/logs/nodes_{ts}.jsonl` (run-scoped, big
-  strings truncated). `interrupt()` gates propagate `GraphInterrupt` through the
-  wrapper, so only `[NODE→]` is logged until resume re-runs the node.
+  strings truncated), ③ a dedicated real-time stream `ml/logs/nodeio_{ts}.log` carrying
+  ONLY the `┌─[NODE→]`/`└─[NODE←]` one-liners (no Slack narration, not the bulky jsonl),
+  per-line flushed via `_node_line()` so `tail -f` gives a live node-boundary view.
+  `_open_node_log(jsonl, live)` opens both handles; the startup banner prints all three
+  paths. `interrupt()` gates propagate `GraphInterrupt` through the wrapper, so only
+  `[NODE→]` is logged until resume re-runs the node.
 - **release artifact archive**: `stage_release` copies the model files to `ml/deploy/{branch}/`
   and commits them to the run branch (tar.gz copied but git-ignored).
 - **interrupt() gates**: deploy / release / converge are independent `interrupt()` nodes. Because
   gates sit at node boundaries, a crash while awaiting Slack approval resumes **without retraining**.
-- **Sheets**: `log_sheet(kind)` DRY factory (`run_start|fe|run_done|converge`).
+- **Sheets**: `log_sheet(kind)` DRY factory (`run_start|fe|run_done|converge`). Each logging node
+  fires its gspread write on a **daemon thread** (serialized by `_SHEET_LOCK`) and returns `{}`
+  immediately — Sheets API latency is off the graph hot path (was a multi-second block).
+- **early convergence (trend)**: `_fe_train_eval` returns `best_obj_gain` (best candidate objective
+  gain this scan); `n_fe_train` accumulates it into `state.obj_hist`; `route_after_fe` converges
+  early (→ converge gate) when the last two rounds' best objective gain are both ≤ 0, instead of
+  always exhausting `--invent_rounds`.
+- **unified termination**: `route_after_fe` routes a *no-adoption* `stop` verdict to the converge
+  gate (proper convergence logging/Sheets), **not** a hard `user_stop`. A hard `user_stop` now means
+  an *adopted* feature the judge distrusts (winner's-curse/overfitting) — removing the prior
+  j_fe-verdict ↔ converge-gate double-decider.
 - **Chaining = graph cycle**: `release → chain → new_branch`. Convergence → `converge → END`.
   `--max_runs` is a state-counter guard; `recursion_limit = max_runs × 25`.
-- **Checkpointer**: `MemorySaver` (in-process). Swap to `SqliteSaver` for cross-restart resume.
+- **State**: `PipelineState` includes `obj_hist` (per-branch round objective-gain history) and
+  `retry_count` (per-stage judge-retry tally) — both reset per branch in `n_new_branch`.
+- **Checkpointer**: `MemorySaver` (in-process) by default. `--persist` builds a `SqliteSaver`
+  (`ml/.pipeline_tmp/checkpoints.db`) for cross-restart resume (a crash while awaiting an
+  interrupt gate resumes without retraining); falls back to `MemorySaver` with a warning if
+  `langgraph-checkpoint-sqlite` is not installed (`pip install langgraph-checkpoint-sqlite`).
 - **Runner**: `run_pipeline` polls `__interrupt__`, gets the Slack decision via `bot.wait_approval`,
   resumes with `Command(resume=decision)`.
 - **Launch**: `python -m ml.orchestrator` (same flags as before + `--invent`, `--invent_rounds`,
-  `--no_judge`, `--claude_model`, `--claude_model_heavy`, `--knowledge/--no-knowledge`).
+  `--no_judge`, `--claude_model`, `--claude_model_heavy`, `--knowledge/--no-knowledge`, `--persist`).
 - **LangSmith tracing**: `orchestrator.py` auto-loads repo-root `.env` (gitignored) at import —
   set `LANGCHAIN_TRACING_V2=true`, `LANGCHAIN_API_KEY`, `LANGCHAIN_PROJECT` there and every
   node run/route is traced to smith.langchain.com with no code changes.
@@ -382,6 +409,7 @@ orchestrator.py defaults:
 - `--scan_ratio`: `1.0` (candidate-scan training subsample ratio, e.g. `0.4`. Baseline + all candidates train on the same seeded subsample for fair ranking; the adopted best is retrained on **full** data. ~2–3× faster scan, best pick usually unchanged.)
 - `--n_anom`: unset → equals `max_mmsi` (anomaly sequences per scenario; larger = less sampling noise in detection rates)
 - `--overall_tol`: `1.0` (adoption regression guard — reject a candidate whose objective rose but whose overall FP=1% detection drops > this many pp)
+- `--persist`: off (when set, uses a `SqliteSaver` checkpointer at `ml/.pipeline_tmp/checkpoints.db` for cross-restart resume; falls back to `MemorySaver` with a warning if `langgraph-checkpoint-sqlite` is missing)
 
 ### Objective function (stability)
 

--- a/ml/PIPELINE.md
+++ b/ml/PIPELINE.md
@@ -10,8 +10,9 @@
 - **1 run = 1 git 브랜치 = 피처 1개 채택 시도** (`dcdetect_001`, `_002`, …).
 - 채택에 성공하면 **체인**(그래프 사이클)으로 다음 브랜치를 시작하고, 더 이상
   목적점수 이득이 없으면 **수렴**하여 종료한다.
-- 각 compute 노드 뒤에는 **판정(judge)** 노드가 붙어 claude 가 `continue / retry / stop`
-  으로 라우팅한다 (LLM-as-judge).
+- 각 compute 노드 뒤에는 **판정(judge)** 노드가 붙는다. 단 **실제 claude 판정은
+  baseline/reco/fe 3개만**(`JUDGE_ON`) `continue / retry / stop` 으로 라우팅(LLM-as-judge);
+  나머지는 LLM 없이 pass-through(`continue`)이거나 결정론적 파이썬 체크다.
 - 비가역 단계(배포·커밋·수렴)에는 **게이트**(`interrupt()` 또는 `--auto_approve`)가 있다.
 - claude 호출(추천·판정·분석)은 **브랜치당 세션 1개**를 공유. 모델은 역할별 분리 —
   판정/지식요약 `--claude_model`(기본 sonnet), 피처발명/상세분석 `--claude_model_heavy`(기본 opus).
@@ -89,7 +90,7 @@
 |---|---|---|---|
 | 🟢 초록 | compute | new_branch · preprocess · fe_baseline · reco_again · fe_train · build · release · chain · converge | 실제 일하는 노드 — 브랜치/전처리/진단/FE/빌드/릴리즈/체인 |
 | 🩷 분홍 | reco | recommend | claude 피처 발명 (opus) — 약세 겨냥 새 lambda |
-| 🟣 보라 | judge | j_branch ~ j_chain (7) | claude 판정 (sonnet) — continue/retry/stop 라우팅 |
+| 🟣 보라 | judge | j_branch ~ j_chain (7) | 이 중 **실제 claude 판정은 j_base/j_reco/j_fe 3개**(sonnet) — continue/retry/stop 라우팅. j_branch/j_release/j_chain 은 pass-through(continue), j_build 는 결정론적 체크(`n_check_build`) |
 | 🟡 노랑 | gate | gate_deploy · gate_release · gate_converge | 사람 승인 (`interrupt()`/auto_approve) — 비가역 관문 |
 | 🔵 파랑 | log | log_run_start · log_fe · log_run_done · log_converge · readme | 기록 — Sheets + 루트 README 결과표 |
 | 🔴 빨강 | stop | user_stop | 중단 종착 — stop verdict/게이트 거부 수렴점 |
@@ -314,24 +315,37 @@ graph TD;
 ### 로그 노드 (Google Sheets)
 
 `log_run_start` / `log_fe` / `log_run_done` / `log_converge` — `log_sheet(kind)` 팩토리(orchestrator.py:185) 1개로 생성.
+Sheets 쓰기는 **데몬 스레드**(락으로 직렬화)로 던지고 노드는 즉시 반환 — gspread 쓰기를 그래프 핫패스에서 뺐다.
 
 ### 판정 노드 (claude 판정)
 
 `j_branch · j_base · j_reco · j_fe · j_build · j_release · j_chain` — 각 compute 노드 뒤에 붙음.
 `claude_judge(stage, ctx_fn)` 팩토리(orchestrator.py:150)로 생성, `build_graph`(orchestrator.py:469) 안에서 `add_node`.
 claude 호출은 `_branch_claude`(orchestrator.py:123) → `_claude_json`(orchestrator.py:92).
-`JUDGE_ON` 에 든 stage 만 동작(`--no_judge` 로 전체 off).
+
+**실제 claude 판정은 `JUDGE_ON = {"baseline","reco","fe"}` 3개만** — 즉 `j_base`/`j_reco`/`j_fe`
+만 LLM 을 호출한다. `new_branch`/`release`/`chain`(`j_branch`/`j_release`/`j_chain`)은 그 단계의
+성공이 결정론적 사실이라 **LLM 없이 `{"decision":"continue"}` 만 반환**(pass-through). `build` 판정
+노드(`j_build`)는 claude 대신 결정론적 파이썬 체크 `n_check_build` — `commit_files > 0` 이면
+continue, 아니면 stop. 결과적으로 브랜치당 claude 판정 호출 7 → 3 으로 감소. `--no_judge` 로 전체 off.
 
 동작: 해당 노드 결과를 claude 에 주고 `{assessment, verdict, reason, suggestion}` JSON 받음 →
 `_route_judge`: **stop→user_stop / retry→직전 노드 재실행 / 그외→다음 노드**.
 
+**retry 예산** — `MAX_JUDGE_RETRY = 2`. `claude_judge` 가 stage별 retry 횟수를
+`state.retry_count` 에 누적, 상한 초과 시 `retry` verdict 을 `continue` 로 강등 →
+recursion_limit 으로만 막히던 flap 루프를 차단.
+
 프롬프트(`_judge_prompt`)는 공통 템플릿에 **stage별 판정 포인트**(`STAGE_FOCUS`)를 주입한다 —
-baseline은 "FE 출발점으로 타당한가", build는 "패치 마커·모델 파일·피처수 일치하나" 처럼
-단계 고유 기준으로 평가(일률 판정 방지). claude 응답이 ```json 펜스로 와도 `_strip_code_fence`
-로 벗겨 파싱한다.
+baseline은 "FE 출발점으로 타당한가" 처럼 단계 고유 기준으로 평가(일률 판정 방지). build 는
+LLM 판정을 쓰지 않으므로 STAGE_FOCUS 대상이 아니다. claude 응답이 ```json 펜스로 와도
+`_strip_code_fence` 로 벗겨 파싱한다.
 
 > `j_fe` 만 예외 — `route_after_fe` 가 판정 verdict + **채택여부**를 결합해 분기
 > (채택O→gate_deploy / 채택X→reco_again 또는 gate_converge / 실패→fe_baseline).
+> 또한 최근 2라운드 best 목적gain 이 모두 ≤0 이면 라운드가 남아도 조기 수렴(→gate_converge),
+> **채택 없음 stop verdict 은 hard user_stop 이 아니라 gate_converge** 로 보낸다(정상 수렴 로깅/Sheets).
+> hard user_stop 은 이제 *채택은 됐으나* 판정이 불신(winner's-curse/overfitting)하는 경우다.
 
 ---
 
@@ -342,7 +356,7 @@ baseline은 "FE 출발점으로 타당한가", build는 "패치 마커·모델 �
 | `route_after_branch_j` orchestrator.py:542 (→`route_after_branch`:418) | j_branch 뒤 | stop이면 user_stop, 아니면 max_runs 체크 → preprocess/fe_baseline/END |
 | `route_after_preprocess` orchestrator.py:425 | preprocess 뒤 | terminate면 END, 아니면 fe_baseline |
 | `_route_judge(next, retry_to)` | 대부분 판정 | stop→user_stop / **retry→직전 노드 재실행** / else→next |
-| `route_after_fe` orchestrator.py:429 | j_fe 뒤 | verdict + 채택여부 결합 (위 설명) |
+| `route_after_fe` orchestrator.py:429 | j_fe 뒤 | verdict + 채택여부 결합 (위 설명). 최근 2라운드 best 목적gain 모두 ≤0 이면 조기 수렴(→gate_converge); 채택 없음 stop 도 user_stop 아닌 gate_converge 로 |
 | `route_gate_deploy` / `route_gate_release` / `route_gate_converge` | 각 게이트 뒤 | approve→진행 / 그외→user_stop(deploy는 retry→fe_baseline) |
 | `route_after_chain` | j_chain 뒤 | stop/retry 우선 → `iters >= max_runs` 면 **빈 브랜치 안 만들고 END** → 아니면 new_branch (사이클) |
 | `build_graph` | — | 전체 노드·엣지 배선 (그래프 정의) |
@@ -364,6 +378,8 @@ baseline은 "FE 출발점으로 타당한가", build는 "패치 마커·모델 �
 | `commit_files`, `build_summary` | 빌드 산출·요약 |
 | `decision`, `judge` | 판정/게이트 결정·노드별 판정 결과 |
 | `adopted_any`, `terminate` | 채택 발생 여부·종료 플래그 |
+| `obj_hist` | 브랜치 내 라운드별 best 목적gain 이력 — 추세 조기수렴 판단(브랜치마다 리셋) |
+| `retry_count` | 단계별 judge retry 횟수 — `MAX_JUDGE_RETRY` 상한(브랜치마다 리셋) |
 
 ---
 
@@ -374,12 +390,17 @@ baseline은 "FE 출발점으로 타당한가", build는 "패치 마커·모델 �
 - **수렴 종료 (횟수 기준)**: 어떤 후보도 목적점수 +`min_gain`(기본 3.0) 못 넘으면 `reco_again`
   으로 다른 각도 재추천 — **브랜치당 `--invent_rounds`(기본 3) 라운드 소진 후에야**
   `gate_converge → converge → END`. 단발 미채택 = 즉시 종료가 아님.
+- **수렴 종료 (추세 기준)**: 최근 2라운드 best 목적gain(`obj_hist`)이 모두 ≤0 이면 라운드가
+  남아 있어도 조기 수렴 — `route_after_fe` 가 횟수 규칙과 별개로 `gate_converge` 로 보낸다.
 - **베이스라인 캐시**: `fe_baseline`(diagnose) 결과 JSON 을 `fe_train` 이 `--baseline_cache` 로
   재사용 — 같은 피처셋이면 베이스라인 재학습 생략 (브랜치당 1회 학습). 재추천 라운드 비용은
   후보 N개 학습만.
 - **세션 격리**: 브랜치마다 새 claude 세션(uuid). 브랜치 내 노드는 맥락 공유, 브랜치 간엔 격리.
 - **thread_id**: run 마다 `orchestrator-{시각}` 발급 (stdout/로그에 출력) — LangSmith Threads 뷰에서
-  run 별로 분리되고, SqliteSaver 도입 시 크래시 재개 키로 쓴다. (고정값이면 전 run 이 한 스레드로 합쳐짐)
+  run 별로 분리되고, `--persist`(SqliteSaver) 시 크래시 재개 키로 쓴다. (고정값이면 전 run 이 한 스레드로 합쳐짐)
+- **체크포인터**: 기본 `MemorySaver`(인프로세스). `--persist` 면 `SqliteSaver`
+  (`ml/.pipeline_tmp/checkpoints.db`) — 게이트 승인 대기 중 크래시/재시작해도 재학습 없이 resume.
+  `langgraph-checkpoint-sqlite` 미설치 시 경고 후 `MemorySaver` 폴백.
 - **develop 복구**: `main()` 의 `finally` 에서 항상 `git checkout develop`.
 
 ---
@@ -396,16 +417,14 @@ baseline은 "FE 출발점으로 타당한가", build는 "패치 마커·모델 �
 
 노드별 모델 배치 (기본값). 원칙: **판정·요약·한줄노트 = sonnet** (잦고 가벼움) /
 **발명·심층분석 = opus** (추론 가치). 전부 같은 브랜치 세션을 모델만 바꿔 resume.
+(`j_branch`/`j_build`/`j_release`/`j_chain` 은 더 이상 claude 를 호출하지 않는다 — pass-through
+또는 결정론적 체크. 위 "판정 노드" 절 참조.)
 
 | claude 호출 노드 | 하는 일 | 모델 | 플래그 |
 |---|---|---|---|
-| `j_branch` | 브랜치 생성 점검 verdict | Sonnet 4.6 | `--claude_model` |
-| `j_base` | 베이스라인 진단 verdict | Sonnet 4.6 | 〃 |
+| `j_base` | 베이스라인 진단 verdict | Sonnet 4.6 | `--claude_model` |
 | `j_reco` | 추천 후보 타당성 verdict | Sonnet 4.6 | 〃 |
 | `j_fe` | FE 채택 결과 verdict (라우팅 결합) | Sonnet 4.6 | 〃 |
-| `j_build` | 빌드 산출 점검 verdict | Sonnet 4.6 | 〃 |
-| `j_release` | 릴리즈 점검 verdict | Sonnet 4.6 | 〃 |
-| `j_chain` | 체인 상태 점검 verdict | Sonnet 4.6 | 〃 |
 | 지식주입+요약 (`_prime_session`) | team-vault 시드 + 한국어 요약 | Sonnet 4.6 | 〃 |
 | `readme` | 루트 README Run Results Note 한 줄 | Sonnet 4.6 | 〃 |
 | **`recommend`** | **새 피처 lambda 발명** | **Opus 4.8** | `--claude_model_heavy` |
@@ -432,6 +451,7 @@ feature_engineer 가 시작 시 로드. 없으면 다음 run 의 `--initial_extr
 |---|---|
 | **`ml/logs/`** (gitignored) | stdout/stderr tee + 모든 Slack 메시지 text(`[HH:MM:SS][브랜치]` 접두사). 시작 시 `run_{시각}.log`, **브랜치 진입마다 `{branch}_{시각}.log` 로 전환** — 파일당 한 브랜치. 머리에 브랜치 구분선 + 풀 claude 세션 uuid |
 | **`ml/logs/nodes_{시각}.jsonl`** (gitignored) | 노드 in/out 전체 레코드. 모든 노드를 `_logged_node` 로 래핑 → ① tee 로그에 `┌─[NODE→]`/`└─[NODE←] name [branch] (elapsed)` 압축 한 줄, ② jsonl 에 `{ts,branch,node,elapsed_s,in,out}` 머신 레코드(거대 문자열 컷). `interrupt()` 게이트는 `GraphInterrupt` 전파 → resume 전까지 `[NODE→]` 만 기록 |
+| **`ml/logs/nodeio_{시각}.log`** (gitignored) | ③ 실시간 스트림 — `┌─[NODE→]`/`└─[NODE←]` 한 줄**만** 모음(Slack 서술·jsonl blob 없음). `_node_line()` 이 줄마다 flush → `tail -f` 로 노드 경계 라이브 관찰 |
 | Slack `#ais-pipeline` | 서술 로그 — 시작그리드·지식요약·판정 verdict·후보표·게이트 |
 | Google Sheets | 구조화 지표 5탭 |
 | LangSmith (`.env` 트레이싱) | 노드 span·라우팅·state·latency (관찰 전용) |
@@ -456,6 +476,7 @@ python -m ml.orchestrator --model dcdetect --epochs 5 --max_mmsi 3000 \
 #   --knowledge/--no-knowledge  team-vault 지식 주입 (기본 on)
 #   --max_runs N              브랜치 체인 안전 상한 (기본 50)
 #   --build_plugin            WSL tar.gz 빌드 (기본 off, 정식 빌드는 native Linux)
+#   --persist                 SqliteSaver 체크포인트 (크래시 후 resume, 기본 off; 미설치 시 MemorySaver 폴백)
 ```
 
 > ⚠️ Slack 버튼 승인(`interrupt()` 게이트)은 SocketMode **인바운드**가 필요하다.

--- a/ml/orchestrator.py
+++ b/ml/orchestrator.py
@@ -117,14 +117,28 @@ class _Tee:
 
 # ─────────────────────────────────────────────
 # 노드 in/out 로깅 — 모든 노드를 _logged_node 로 감싸 입력 state·출력 delta 기록
-#   ① 압축 한 줄 → tee 로그(ml/logs/{branch}.log) [NODE→]/[NODE←]
+#   ① 압축 한 줄 → tee 로그(ml/logs/{branch}.log) [NODE→]/[NODE←] (Slack 서술과 섞임)
 #   ② 전체 레코드 → ml/logs/nodes_{ts}.jsonl (머신 파싱용, 큰 문자열만 컷)
+#   ③ in/out 한 줄만 모은 실시간 스트림 → ml/logs/nodeio_{ts}.log (tail -f 용, 노드 IO만)
 # ─────────────────────────────────────────────
-_NODE_LOG = {"f": None}   # nodes_{ts}.jsonl 핸들 (run 단위 1개)
+_NODE_LOG = {"f": None, "live": None}   # f=jsonl 핸들, live=nodeio 스트림 핸들 (run 단위 1개)
 
 
-def _open_node_log(path):
-    _NODE_LOG["f"] = open(path, "a", encoding="utf-8", errors="replace")
+def _open_node_log(jsonl_path, live_path=None):
+    _NODE_LOG["f"] = open(jsonl_path, "a", encoding="utf-8", errors="replace")
+    if live_path is not None:
+        _NODE_LOG["live"] = open(live_path, "a", encoding="utf-8", errors="replace")
+
+
+def _node_line(line: str):
+    """[NODE→]/[NODE←] 한 줄을 stdout(tee)·전용 nodeio 스트림 양쪽에 즉시 기록."""
+    print(line)
+    if _NODE_LOG["live"]:
+        try:
+            _NODE_LOG["live"].write(line + "\n")
+            _NODE_LOG["live"].flush()
+        except Exception:
+            pass
 
 
 def _io_summary(obj, maxlen: int = 300) -> str:
@@ -159,11 +173,11 @@ def _logged_node(name: str, fn):
     (try/except 로 삼키면 LangGraph 일시정지가 깨짐). 정상 반환만 [NODE←]/jsonl 기록."""
     def wrapped(state: PipelineState) -> dict:
         br = state.get("branch", "-")
-        print(f"┌─[NODE→] {name} [{br}] | in={_io_summary(state)}")
+        _node_line(f"┌─[NODE→] {name} [{br}] | in={_io_summary(state)}")
         t0 = time.time()
         out = fn(state)                        # interrupt 시 여기서 GraphInterrupt 전파 → 아래 생략
         dt = time.time() - t0
-        print(f"└─[NODE←] {name} [{br}] ({dt:.1f}s) | out={_io_summary(out)}")
+        _node_line(f"└─[NODE←] {name} [{br}] ({dt:.1f}s) | out={_io_summary(out)}")
         if _NODE_LOG["f"]:
             try:
                 rec = {"ts": time.strftime("%H:%M:%S"), "branch": br, "node": name,
@@ -953,10 +967,11 @@ def main():
     Path("ml/logs").mkdir(parents=True, exist_ok=True)
     _ts0 = time.strftime("%Y%m%d_%H%M%S")
     _switch_log(Path("ml/logs") / f"run_{_ts0}.log")
-    _open_node_log(Path("ml/logs") / f"nodes_{_ts0}.jsonl")   # 노드 in/out 전체 레코드
+    _open_node_log(Path("ml/logs") / f"nodes_{_ts0}.jsonl",      # 노드 in/out 전체 레코드(jsonl)
+                   Path("ml/logs") / f"nodeio_{_ts0}.log")        # in/out 한 줄 실시간 스트림
     sys.stdout = _Tee(sys.stdout)
     sys.stderr = _Tee(sys.stderr)
-    print(f"[로그] {_LOG['path']}  |  노드IO: ml/logs/nodes_{_ts0}.jsonl")
+    print(f"[로그] {_LOG['path']}  |  노드IO: ml/logs/nodes_{_ts0}.jsonl  |  실시간: ml/logs/nodeio_{_ts0}.log")
 
     steps._AUTO_APPROVE = args.auto_approve
     if args.no_judge:

--- a/ml/orchestrator.py
+++ b/ml/orchestrator.py
@@ -21,6 +21,7 @@ import json
 import os
 import subprocess
 import sys
+import threading
 import time
 import uuid
 from pathlib import Path
@@ -45,8 +46,15 @@ import ml.integrations.slack_bot as _sb
 import ml.integrations.sheets as _sh
 import ml.integrations.git_manager as git
 
-# 판정(judge)을 켤 노드 (전체). 비용 줄이려면 일부만 남긴다.
-JUDGE_ON = {"new_branch", "baseline", "reco", "fe", "build", "release", "chain"}
+# 판정(judge)을 LLM 으로 돌릴 노드 — **분석형만**.
+#   new_branch/release/chain 은 자명한 사실(브랜치/커밋/저장 성공)이라 LLM 무가치 → 패스스루
+#   (claude_judge 가 JUDGE_ON 밖 stage 는 LLM 없이 continue 즉답).
+#   build 는 빈 commit_files 가 예외 없이 통과할 수 있어 결정적 체크 노드(n_check_build)로 대체.
+#   남기는 건 진짜 추론이 필요한 baseline(약세진단)·reco(중복/유효성)·fe(채택/회귀 분석)뿐.
+JUDGE_ON = {"baseline", "reco", "fe"}
+
+# judge verdict=retry 의 단계별 재시도 상한 — 초과 시 continue 로 강등(플랩 방지).
+MAX_JUDGE_RETRY = 2
 
 # 노드별 판정 포인트 — 같은 템플릿이지만 단계 고유의 관점을 주입해
 # claude 가 그 단계에 맞는 기준으로 평가하게 한다 (일률 판정 방지).
@@ -241,6 +249,8 @@ class PipelineState(TypedDict, total=False):
     judge: dict             # 노드별 판정 결과
     adopted_any: bool
     terminate: bool
+    obj_hist: list            # 브랜치 내 reco 라운드별 best 목적gain (추세 조기수렴용)
+    retry_count: dict         # 단계별 judge retry 횟수 (MAX_JUDGE_RETRY 상한)
 
 
 # ─────────────────────────────────────────────
@@ -365,6 +375,16 @@ def claude_judge(stage: str, ctx_fn):
         v = _branch_claude(_judge_prompt(stage, text, extra)) or {
             "assessment": "분석 불가(claude 없음)", "verdict": "continue", "reason": "fallback"}
         verdict = v.get("verdict", "continue")
+        out = {"judge": {**state.get("judge", {}), stage: v}}
+        # retry 예산 — 같은 단계 retry 가 MAX_JUDGE_RETRY 초과면 continue 로 강등(무한 플랩 방지)
+        if verdict == "retry":
+            rc = dict(state.get("retry_count", {}))
+            n = rc.get(stage, 0) + 1
+            if n > MAX_JUDGE_RETRY:
+                RT.bot.log(f"⚠️ [{stage}] judge retry {MAX_JUDGE_RETRY}회 초과 — continue 강등", "warning")
+                verdict = "continue"
+            rc[stage] = n
+            out["retry_count"] = rc
         sug = (v.get("suggestion") or "").strip()
         has_sug = sug and sug.lower() not in ("없음", "none", "n/a", "-", "null", "없음.")
         RT.bot.log(
@@ -373,7 +393,8 @@ def claude_judge(stage: str, ctx_fn):
             + (f"\n  💡 {sug}" if has_sug else ""),
             "판정",
         )
-        return {"judge": {**state.get("judge", {}), stage: v}, "decision": verdict}
+        out["decision"] = verdict
+        return out
     return node
 
 
@@ -381,7 +402,8 @@ def _route_judge(continue_to: str, retry_to: str):
     """판정 verdict → continue_to / retry_to / user_stop(stop).
 
     retry 는 **직전 노드 재실행** — 예전엔 일률 fe_train 으로 보내
-    j_base retry 가 후보 0인 채 스캔에 진입하는 등 비논리적이었다."""
+    j_base retry 가 후보 0인 채 스캔에 진입하는 등 비논리적이었다.
+    (retry 횟수 상한은 claude_judge 가 MAX_JUDGE_RETRY 로 강등 처리.)"""
     def route(state: PipelineState) -> str:
         d = state.get("decision", "continue")
         if d == "stop":
@@ -392,32 +414,58 @@ def _route_judge(continue_to: str, retry_to: str):
     return route
 
 
+def n_check_build(state: PipelineState) -> dict:
+    """build 산출 결정적 검증 — claude judge 대체. 커밋 파일 없으면(부분 실패) stop.
+    (_fe_build_and_release 는 빈 commit_files 를 예외 없이 반환할 수 있어 명시 체크가 필요.)"""
+    ok = len(state.get("commit_files", [])) > 0
+    if not ok:
+        RT.bot.log("⚠️ [build] 커밋 산출 파일 0개 — 빌드 부분 실패로 간주 → stop", "warning")
+    return {"decision": "continue" if ok else "stop"}
+
+
 # ─────────────────────────────────────────────
 # Sheets 로깅 DRY 팩토리
 # ─────────────────────────────────────────────
+# Sheets API 는 그래프 임계경로에서 떼어 비동기 발사 — 노드는 즉시 리턴.
+# 단일 gspread 클라이언트 동시호출 경쟁 방지로 lock 직렬화. 관찰용이라 best-effort.
+_SHEET_LOCK = threading.Lock()
+
+
 def log_sheet(kind: str):
-    """kind: run_start|fe|run_done|converge. 동일 로깅 노드 복제 대신 하나로."""
+    """kind: run_start|fe|run_done|converge. 동일 로깅 노드 복제 대신 하나로.
+    Sheets 쓰기는 데몬 스레드로 발사하고 노드는 즉시 {} 반환(핫패스 비차단)."""
     def node(state: PipelineState) -> dict:
         s, r, a = RT.sheet, state.get("r", {}), RT.args
-        try:
-            if kind == "run_start":
-                s.log_run_start(state["branch"], a.model, a.epochs, a.max_mmsi,
-                                data_file=a.data_file)
-            elif kind == "fe":
-                fe = r.get("fe_stats", {})
-                s.log_fe(state["branch"], state["run_num"], "완료",
-                         model=a.model, fe_step=len(r.get("newly_adopted", [])),
-                         baseline_det=fe.get("baseline_det"), best_det=fe.get("det_rate"),
-                         n_features=r.get("n_feat"), adopted=r.get("newly_adopted"),
-                         all_features=r.get("full_extra"),
-                         threshold=fe.get("threshold"))
-            elif kind == "run_done":
-                s.log_run_done(state["branch"], a.model, success=True)
-            elif kind == "converge":
-                s.update_run_summary(notes="수렴 완료",
-                                     adopted=state.get("current_extra"))
-        except Exception as e:
-            print(f"[Sheets:{kind}] 로깅 실패(무시): {e}")
+        # 스레드에서 쓸 값은 호출 시점에 스냅샷(이후 state 변화와 무관하게).
+        branch = state.get("branch", "?")
+        run_num = state.get("run_num")
+        current_extra = state.get("current_extra")
+        fe = dict(r.get("fe_stats", {}))
+        newly_adopted = list(r.get("newly_adopted", []))
+        full_extra = list(r.get("full_extra", []))
+        n_feat = r.get("n_feat")
+
+        def _do():
+            with _SHEET_LOCK:
+                try:
+                    if kind == "run_start":
+                        s.log_run_start(branch, a.model, a.epochs, a.max_mmsi,
+                                        data_file=a.data_file)
+                    elif kind == "fe":
+                        s.log_fe(branch, run_num, "완료",
+                                 model=a.model, fe_step=len(newly_adopted),
+                                 baseline_det=fe.get("baseline_det"), best_det=fe.get("det_rate"),
+                                 n_features=n_feat, adopted=newly_adopted,
+                                 all_features=full_extra,
+                                 threshold=fe.get("threshold"))
+                    elif kind == "run_done":
+                        s.log_run_done(branch, a.model, success=True)
+                    elif kind == "converge":
+                        s.update_run_summary(notes="수렴 완료", adopted=current_extra)
+                except Exception as e:
+                    print(f"[Sheets:{kind}] 로깅 실패(무시): {e}")
+
+        threading.Thread(target=_do, daemon=True, name=f"sheet-{kind}").start()
         return {}
     return node
 
@@ -466,9 +514,11 @@ def n_new_branch(state: PipelineState) -> dict:
         "출발 피처": f"{len(state.get('current_extra', []))}개 (기채택)",
         "claude세션": RT.claude_sid[:8],
     })
-    # reco_round 는 브랜치 단위 리셋 — 각 브랜치가 invent_rounds 만큼 재추천 기회를 가짐
+    # reco_round·obj_hist·retry_count 는 브랜치 단위 리셋 — 각 브랜치가 invent_rounds 만큼
+    # 재추천 기회를 갖고, 추세/재시도 카운트가 이전 브랜치로 누설되지 않게 한다.
     return {"run_num": run_num, "branch": branch,
-            "iters": state.get("iters", 0) + 1, "reco_round": 1}
+            "iters": state.get("iters", 0) + 1, "reco_round": 1,
+            "obj_hist": [], "retry_count": {}}
 
 
 def n_preprocess(state: PipelineState) -> dict:
@@ -608,7 +658,12 @@ def n_fe_train(state: PipelineState) -> dict:
     steps.WORK_DIR.mkdir(parents=True, exist_ok=True)
     r = steps._fe_train_eval(RT.bot, RT.sheet, state["branch"], RT.args,
                              state["run_num"], state["current_extra"], steps.WORK_DIR, si)
-    return {"r": r, "first_iter": False}
+    # 이번 라운드 best 후보 목적gain 을 추세 히스토리에 누적(조기수렴 판단용).
+    hist = list(state.get("obj_hist", []))
+    bog = r.get("best_obj_gain")
+    if bog is not None:
+        hist.append(bog)
+    return {"r": r, "first_iter": False, "obj_hist": hist}
 
 
 def n_build(state: PipelineState) -> dict:
@@ -792,20 +847,32 @@ def route_after_preprocess(state: PipelineState) -> str:
 
 
 def route_after_fe(state: PipelineState) -> str:
-    """판정 verdict + 채택여부 결합 라우팅."""
+    """판정 verdict + 채택여부 결합 라우팅.
+
+    종료 경로 일원화: 미채택 상황의 'stop' 은 하드 user_stop 이 아니라 converge 게이트로
+    보낸다 (수렴 로깅/Sheets 를 거쳐 정상 종료). 하드 stop 은 '채택했는데 judge 가 불신'
+    하는 경우(과적합 의심)로 한정 — 두 종료 결정자(j_fe verdict ↔ converge)의 중복 제거."""
     d = state.get("decision", "continue")
-    if d == "stop":
-        return "user_stop"
+    r = state.get("r", {})
     if d == "retry":
         return "fe_baseline"
-    r = state.get("r", {})
     if r.get("ret", 0) != 0:
         return "fe_baseline"           # 실패 → 재진단/재시도
     if r.get("newly_adopted"):
-        return "gate_deploy"
-    # 수렴 판단에 횟수 기준: 이 브랜치에서 미채택이라도 invent_rounds 까지
-    # 다른 각도로 재추천 (라운드 비용은 baseline_cache 로 후보 학습만).
-    # 모든 라운드 소진 후에야 수렴 게이트로 — 단발 미채택 = 즉시 종료 방지.
+        # 채택 + judge stop = 채택 불신(winner's curse/과적합) → 하드 정지. 아니면 배포.
+        return "user_stop" if d == "stop" else "gate_deploy"
+    # ── 미채택 경로 ──
+    if d == "stop":                    # judge 가 수렴 권고 → converge 로 일원화
+        RT.bot.log("⛔ [fe] judge stop(미채택) — 수렴 게이트로", "피처개선")
+        return "gate_converge"
+    # 추세 조기수렴: 최근 2라운드 best 목적gain 이 모두 ≤0 이면 라운드 남아도 수렴
+    # (음수 2연속이면 회복 확률 낮음 — 낭비 fe_train 라운드 컷).
+    hist = state.get("obj_hist", [])
+    if len(hist) >= 2 and max(hist[-2:]) <= 0:
+        RT.bot.log(f"⛔ [fe] 최근 2라운드 목적gain ≤0 {hist[-2:]} — 추세 조기수렴", "피처개선")
+        return "gate_converge"
+    # 횟수 기준: 미채택이라도 invent_rounds 까지 다른 각도로 재추천
+    # (라운드 비용은 baseline_cache 로 후보 학습만). 단발 미채택 = 즉시 종료 방지.
     if (RT.args.invent and RT.args.invent > 0
             and state.get("reco_round", 1) < RT.args.invent_rounds):
         return "reco_again"
@@ -832,6 +899,22 @@ def route_gate_converge(state: PipelineState) -> str:
 # ─────────────────────────────────────────────
 # 그래프
 # ─────────────────────────────────────────────
+def _make_checkpointer(persist: bool):
+    """persist=True → SqliteSaver(크래시 후 resume). 불가/미설치 시 MemorySaver 폴백."""
+    if not persist:
+        return MemorySaver()
+    try:
+        import sqlite3
+        from langgraph.checkpoint.sqlite import SqliteSaver
+        Path("ml/.pipeline_tmp").mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect("ml/.pipeline_tmp/checkpoints.db", check_same_thread=False)
+        print("[checkpoint] SqliteSaver 활성 — ml/.pipeline_tmp/checkpoints.db")
+        return SqliteSaver(conn)
+    except Exception as e:
+        print(f"[checkpoint] Sqlite 불가({e}) → MemorySaver 폴백")
+        return MemorySaver()
+
+
 def build_graph(checkpointer=None):
     g = StateGraph(PipelineState)
 
@@ -853,7 +936,7 @@ def build_graph(checkpointer=None):
     g.add_node("j_base", _logged_node("j_base", claude_judge("baseline", lambda s: (s["baseline"]["out"], {"det": s["baseline"]["det"]}))))
     g.add_node("j_reco", _logged_node("j_reco", claude_judge("reco", lambda s: (", ".join(s.get("candidates", [])), {"n": len(s.get("candidates", []))}))))
     g.add_node("j_fe", _logged_node("j_fe", claude_judge("fe", lambda s: ("\n".join(s["r"].get("summary", [])), s["r"].get("fe_stats", {})))))
-    g.add_node("j_build", _logged_node("j_build", claude_judge("build", lambda s: ("\n".join(s.get("build_summary", [])), {}))))
+    g.add_node("j_build", _logged_node("j_build", n_check_build))   # 결정적 체크(LLM 아님)
     g.add_node("j_release", _logged_node("j_release", claude_judge("release", lambda s: (s["branch"], {"det": s["r"].get("det_str")}))))
     g.add_node("j_chain", _logged_node("j_chain", claude_judge("chain", lambda s: (", ".join(s.get("current_extra", [])), {}))))
 
@@ -960,6 +1043,9 @@ def main():
     p.add_argument("--knowledge", action=argparse.BooleanOptionalAction, default=True,
                    help="team-vault 도메인 지식(ML IDS·공격 시나리오)을 브랜치 세션에 주입. "
                         "끄려면 --no_knowledge.")
+    p.add_argument("--persist", action="store_true",
+                   help="SqliteSaver 체크포인트(ml/.pipeline_tmp/checkpoints.db) — 게이트 대기중 "
+                        "크래시/재시작해도 재학습 없이 resume. 기본 off(MemorySaver, 인프로세스).")
     args = p.parse_args()
 
     # ── 영구 파일 로깅: stdout/stderr tee + Slack 서술 로그 ──
@@ -994,7 +1080,7 @@ def main():
         "current_extra": steps._load_fe_initial_extra(),
         "tried_feats": [], "adopted_any": False, "terminate": False,
     }
-    graph = build_graph()
+    graph = build_graph(checkpointer=_make_checkpointer(args.persist))
     # thread_id 를 run 마다 분리 — 고정값이면 LangSmith Threads 뷰에서 모든 run 이
     # 한 스레드의 턴으로 합쳐져 새 run 이 안 보이는 것처럼 보인다.
     thread_id = f"orchestrator-{time.strftime('%Y%m%d_%H%M%S')}"

--- a/ml/pipeline_steps.py
+++ b/ml/pipeline_steps.py
@@ -902,10 +902,12 @@ def _fe_train_eval(bot, sheet, branch, args, run_num, current_initial_extra, fe_
     det_str  = f"{det_rate:.1f}" if det_rate is not None else "?"
     n_feat_s = str(n_feat) if n_feat else "?"
     scaler_path = str(WORK_DIR / "model" / f"scaler_{args.model}.json")
+    # 이번 스캔의 최고 후보 목적gain (candidates 는 obj_gain 내림차순) — 추세 조기수렴용.
+    best_obj_gain = candidates[0][4] if candidates else None
     return {
         "ret": 0, "summary": summary, "fe_stats": fe_stats,
         "newly_adopted": newly_adopted, "full_extra": full_extra,
-        "det_rate": det_rate, "det_str": det_str,
+        "det_rate": det_rate, "det_str": det_str, "best_obj_gain": best_obj_gain,
         "n_feat": n_feat, "n_feat_s": n_feat_s, "scaler_path": scaler_path,
     }
 


### PR DESCRIPTION
## 요약
클라우드 자동화 루틴(/brief 주간, /change-report 매일)이 org main을 클론하므로, 스킬들을 main에 올린다. orchestrator judge 개편 등 develop 누적분도 함께 릴리스.

## 스킬
- **brief** (신규): 교수님 한글 진행 브리핑 → Notion. PR 맥락 + 회의록 + 실험결과 종합. 개발 changelog와 분리.
- **read-docs** (신규): repo 실문서 읽고 벤더 README 제외, Explore 병렬 fan-out 영역별 요약.
- **change-report** (확장): Step 0 회의록 수집 + Meeting context/Alignment 섹션.
- **repo-status** (신규): 로컬↔원격 divergence 읽기전용 리뷰.

## orchestrator
- judge 강등 7→3 (`JUDGE_ON`={baseline,reco,fe}, `n_check_build`), 추세기반 조기수렴(`obj_hist`), judge 재시도 예산(`MAX_JUDGE_RETRY=2`), `--persist`(SqliteSaver), 비동기 Sheets, 종료경로 통합, 실시간 node-IO 싱크(`nodeio_{ts}.log`).
- 문서 동기화: CLAUDE.md + PIPELINE.md.

## 커밋 (6)
8263298 skills: brief+read-docs+change-report / e533eaf sync-docs / 7aa124a docs sync / ab72c39 orchestrator 개편 / 4856cea nodeio / 6791a8c repo-status

🤖 Generated with [Claude Code](https://claude.com/claude-code)